### PR TITLE
PMM-2090 Fix external exporters add deadlock.

### DIFF
--- a/services/prometheus/scrape_configs.go
+++ b/services/prometheus/scrape_configs.go
@@ -263,6 +263,7 @@ func (svc *Service) checkReachability(ctx context.Context, cfg *ScrapeConfig, ta
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
 				reachabilityCh <- ScrapeTargetReachability{target, fmt.Sprintf("unexpected response status code %d", resp.StatusCode)}
+				return
 			}
 			reachabilityCh <- ScrapeTargetReachability{target, ""}
 		}(target)


### PR DESCRIPTION
It happens when exporter is reachable, but returns
HTTP code other than 200. Typically it is 404 if
metrics path is incorrect.