### PR TITLE
PMM-3061 Set default port

### DIFF
--- a/services/mysql/mysql.go
+++ b/services/mysql/mysql.go
@@ -41,7 +41,8 @@ import (
 )
 
 const (
-	qanAgentPort uint16 = 9000
+	qanAgentPort     uint16 = 9000
+	defaultMySQLPort uint32 = 3306
 )
 
 type ServiceConfig struct {
@@ -349,11 +350,11 @@ func (svc *Service) Add(ctx context.Context, name, address string, port uint32, 
 	if address == "" {
 		return 0, status.Error(codes.InvalidArgument, "MySQL instance host is not given.")
 	}
-	if port == 0 {
-		return 0, status.Error(codes.InvalidArgument, "MySQL instance port is not given.")
-	}
 	if username == "" {
 		return 0, status.Error(codes.InvalidArgument, "Username is not given.")
+	}
+	if port == 0 {
+		port = defaultMySQLPort
 	}
 	if name == "" {
 		name = address

--- a/services/mysql/mysql_test.go
+++ b/services/mysql/mysql_test.go
@@ -168,13 +168,10 @@ func TestAddListRemove(t *testing.T) {
 	_, err = svc.Add(ctx, "", "", 0, "username", "password")
 	tests.AssertGRPCError(t, status.New(codes.InvalidArgument, `MySQL instance host is not given.`), err)
 
-	_, err = svc.Add(ctx, "", "localhost", 0, "username", "password")
-	tests.AssertGRPCError(t, status.New(codes.InvalidArgument, `MySQL instance port is not given.`), err)
-
 	supervisor.On("Start", mock.Anything, mock.Anything).Return(nil)
 	supervisor.On("Status", mock.Anything, mock.Anything).Return(fmt.Errorf("not running"))
 	supervisor.On("Stop", mock.Anything, mock.Anything).Return(nil)
-	id, err := svc.Add(ctx, "", "localhost", 3306, "pmm-managed", "pmm-managed")
+	id, err := svc.Add(ctx, "", "localhost", 0, "pmm-managed", "pmm-managed")
 	assert.NoError(t, err)
 
 	_, err = svc.Add(ctx, "", "localhost", 3306, "pmm-managed", "pmm-managed")

--- a/services/postgresql/postgresql.go
+++ b/services/postgresql/postgresql.go
@@ -41,6 +41,8 @@ import (
 	"github.com/percona/pmm-managed/utils/ports"
 )
 
+const defaultPostgreSQLPort uint32 = 5432
+
 // regexps to extract version numbers from the `SELECT Version();` output
 var (
 	postgresDBRegexp  = regexp.MustCompile(`PostgreSQL ([\d\.]+)`)
@@ -75,6 +77,7 @@ func NewService(config *ServiceConfig) (*Service, error) {
 	} {
 		if *path == "" {
 			continue
+			const defaultPostgresPort = 5432
 		}
 		p, err := exec.LookPath(*path)
 		if err != nil {
@@ -196,11 +199,11 @@ func (svc *Service) Add(ctx context.Context, name, address string, port uint32, 
 	if address == "" {
 		return 0, status.Error(codes.InvalidArgument, "PostgreSQL instance host is not given.")
 	}
-	if port == 0 {
-		return 0, status.Error(codes.InvalidArgument, "PostgreSQL instance port is not given.")
-	}
 	if username == "" {
 		return 0, status.Error(codes.InvalidArgument, "Username is not given.")
+	}
+	if port == 0 {
+		port = defaultPostgreSQLPort
 	}
 	if name == "" {
 		name = address

--- a/services/postgresql/postgresql.go
+++ b/services/postgresql/postgresql.go
@@ -77,7 +77,6 @@ func NewService(config *ServiceConfig) (*Service, error) {
 	} {
 		if *path == "" {
 			continue
-			const defaultPostgresPort = 5432
 		}
 		p, err := exec.LookPath(*path)
 		if err != nil {

--- a/services/postgresql/postgresql_test.go
+++ b/services/postgresql/postgresql_test.go
@@ -92,12 +92,9 @@ func TestAddListRemove(t *testing.T) {
 	_, err = svc.Add(ctx, "", "", 0, "username", "password")
 	tests.AssertGRPCError(t, status.New(codes.InvalidArgument, `PostgreSQL instance host is not given.`), err)
 
-	_, err = svc.Add(ctx, "", "localhost", 0, "username", "password")
-	tests.AssertGRPCError(t, status.New(codes.InvalidArgument, `PostgreSQL instance port is not given.`), err)
-
 	supervisor.On("Start", mock.Anything, mock.Anything).Return(nil)
 	supervisor.On("Stop", mock.Anything, mock.Anything).Return(nil)
-	id, err := svc.Add(ctx, "", "localhost", 5432, "username", "password")
+	id, err := svc.Add(ctx, "", "localhost", 0, "username", "password")
 	assert.NoError(t, err)
 
 	_, err = svc.Add(ctx, "", "localhost", 5432, "username", "password")


### PR DESCRIPTION
Set default port for MySQL and PostgreSQL if port is not presented in Add request.