### PR TITLE
PMM-3061 Fixed service not found error

### DIFF
--- a/services/mysql/mysql.go
+++ b/services/mysql/mysql.go
@@ -137,8 +137,11 @@ func (svc *Service) ApplyPrometheusConfiguration(ctx context.Context, q *reform.
 		node := n.(*models.RemoteNode)
 
 		var service models.MySQLService
-		if e := q.SelectOneTo(&service, "WHERE node_id = ? and type = ?", node.ID, models.MySQLServiceType); e != nil {
+		if e := q.SelectOneTo(&service, "WHERE node_id = ?", node.ID); e != nil {
 			return errors.WithStack(e)
+		}
+		if service.Type != models.MySQLServiceType {
+			continue
 		}
 
 		agents, err := models.AgentsForServiceID(q, service.ID)

--- a/services/postgresql/postgresql.go
+++ b/services/postgresql/postgresql.go
@@ -113,8 +113,11 @@ func (svc *Service) ApplyPrometheusConfiguration(ctx context.Context, q *reform.
 		node := n.(*models.RemoteNode)
 
 		var service models.PostgreSQLService
-		if e := q.SelectOneTo(&service, "WHERE node_id = ? and type = ?", node.ID, models.PostgreSQLServiceType); e != nil {
+		if e := q.SelectOneTo(&service, "WHERE node_id = ?", node.ID); e != nil {
 			return errors.WithStack(e)
+		}
+		if service.Type != models.PostgreSQLServiceType {
+			continue
 		}
 
 		agents, err := models.AgentsForServiceID(q, service.ID)

--- a/services/postgresql/postgresql.go
+++ b/services/postgresql/postgresql.go
@@ -112,10 +112,14 @@ func (svc *Service) ApplyPrometheusConfiguration(ctx context.Context, q *reform.
 	for _, n := range nodes {
 		node := n.(*models.RemoteNode)
 
-		var service models.PostgreSQLService
-		if e := q.SelectOneTo(&service, "WHERE node_id = ?", node.ID); e != nil {
+		postgreSQLServices, e := q.SelectAllFrom(models.PostgreSQLServiceTable, "WHERE node_id = ?", node.ID)
+		if e != nil {
 			return errors.WithStack(e)
 		}
+		if len(postgreSQLServices) != 1 {
+			return errors.Errorf("expected to fetch 1 record, fetched %d. %v", len(postgreSQLServices), postgreSQLServices)
+		}
+		service := postgreSQLServices[0].(*models.PostgreSQLService)
 		if service.Type != models.PostgreSQLServiceType {
 			continue
 		}
@@ -447,9 +451,16 @@ func (svc *Service) Restore(ctx context.Context, tx *reform.TX) error {
 	for _, n := range nodes {
 		node := n.(*models.RemoteNode)
 
-		service := &models.PostgreSQLService{}
-		if e := tx.SelectOneTo(service, "WHERE node_id = ?", node.ID); e != nil {
+		postgreSQLServices, e := tx.SelectAllFrom(models.PostgreSQLServiceTable, "WHERE node_id = ?", node.ID)
+		if e != nil {
 			return errors.WithStack(e)
+		}
+		if len(postgreSQLServices) != 1 {
+			return errors.Errorf("expected to fetch 1 record, fetched %d. %v", len(postgreSQLServices), postgreSQLServices)
+		}
+		service := postgreSQLServices[0].(*models.PostgreSQLService)
+		if service.Type != models.PostgreSQLServiceType {
+			continue
 		}
 
 		agents, err := models.AgentsForServiceID(tx.Querier, service.ID)


### PR DESCRIPTION
Got this error on initialize if user has added PostgreSQL or MySQL instance and restarted pmm-server.
msg="PostgreSQL service problem: sql: no rows in result set\ngithub.com/percona/pmm-managed/services/mysql.(*Service).ApplyPrometheusConfiguration\n\t/home/builder/rpm/BUILD/pmm-managed-a9633ca109431f724c1a69427194c1117a83aca5/src/github.com/percona/pmm-managed/services/mysql/mysql.go:140"