### PR TITLE
Skip non-trunk PMM-XXXX branch builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ matrix:
   allow_failures:
     - go: master
 
+# skip non-trunk PMM-XXXX branch builds, but still build pull requests
+branches:
+  except:
+    - /^PMM\-\d{4}/
+
 cache:
   directories:
     - /home/travis/.cache/go-build


### PR DESCRIPTION
We still need builds for PMM-2.0 branch to calculate code coverage changes correctly: https://docs.codecov.io/docs/error-reference#section-missing-base-commit