### PR TITLE
SAAS-321 - env variables

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -830,6 +830,7 @@
   input-imports = [
     "github.com/AlekSi/pointer",
     "github.com/BurntSushi/go-sumtype",
+    "github.com/asaskevich/govalidator",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/credentials",

--- a/services/checks/checks.go
+++ b/services/checks/checks.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/percona/pmm-managed/utils/envvars"
-
 	"github.com/AlekSi/pointer"
 	api "github.com/percona-platform/saas/gen/check/retrieval"
 	"github.com/percona-platform/saas/pkg/check"
@@ -45,6 +43,7 @@ import (
 
 	"github.com/percona/pmm-managed/models"
 	"github.com/percona/pmm-managed/services"
+	"github.com/percona/pmm-managed/utils/envvars"
 )
 
 const (
@@ -687,6 +686,7 @@ func (s *Service) pickPMMAgent(agents []*models.Agent, minPMMAgentVersion *versi
 		v, err := version.Parse(pointer.GetString(a.Version))
 		if err != nil {
 			s.l.Warnf("Failed to parse pmm-agent version: %s.", err)
+
 			continue
 		}
 

--- a/services/platform/platform.go
+++ b/services/platform/platform.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/percona/pmm-managed/utils/envvars"
+
 	api "github.com/percona-platform/saas/gen/auth"
 	"github.com/percona/pmm/utils/tlsconfig"
 	"github.com/percona/pmm/version"
@@ -39,11 +41,9 @@ import (
 )
 
 const (
-	defaultHost                   = "check.percona.com:443"
 	defaultSessionRefreshInterval = 24 * time.Hour
 	dialTimeout                   = 5 * time.Second
 
-	envHost                   = "PERCONA_TEST_AUTH_HOST"
 	envSessionRefreshInterval = "PERCONA_TEST_SESSION_REFRESH_INTERVAL"
 
 	authType = "PP-1"
@@ -64,16 +64,13 @@ func New(db *reform.DB) *Service {
 	l := logrus.WithField("component", "auth")
 
 	s := Service{
-		host:                   defaultHost,
+		host:                   "",
 		sessionRefreshInterval: defaultSessionRefreshInterval,
 		db:                     db,
 		l:                      l,
 	}
 
-	if h := os.Getenv(envHost); h != "" {
-		l.Warnf("Host changed to %s.", h)
-		s.host = h
-	}
+	s.host = envvars.GetSAASHost()
 
 	if d, err := time.ParseDuration(os.Getenv(envSessionRefreshInterval)); err == nil && d > 0 {
 		l.Warnf("Session refresh interval changed to %s.", d)

--- a/services/platform/platform.go
+++ b/services/platform/platform.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/percona/pmm-managed/utils/envvars"
-
 	api "github.com/percona-platform/saas/gen/auth"
 	"github.com/percona/pmm/utils/tlsconfig"
 	"github.com/percona/pmm/version"
@@ -38,6 +36,7 @@ import (
 	"gopkg.in/reform.v1"
 
 	"github.com/percona/pmm-managed/models"
+	"github.com/percona/pmm-managed/utils/envvars"
 )
 
 const (

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/percona/pmm-managed/utils/envvars"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
@@ -49,7 +51,6 @@ import (
 
 const (
 	defaultV1URL        = "https://v.percona.com/"
-	defaultV2Host       = "check.percona.com:443" // protocol is always https
 	defaultInterval     = 24 * time.Hour
 	defaultRetryBackoff = time.Hour
 	defaultRetryCount   = 20
@@ -57,7 +58,6 @@ const (
 	// Environment variables that affect telemetry service; only for testing.
 	// DISABLE_TELEMETRY environment variable is handled elsewere.
 	envV1URL        = "PERCONA_VERSION_CHECK_URL" // the same name as for the Toolkit
-	envV2Host       = "PERCONA_TEST_TELEMETRY_HOST"
 	envInterval     = "PERCONA_TEST_TELEMETRY_INTERVAL"
 	envRetryBackoff = "PERCONA_TEST_TELEMETRY_RETRY_BACKOFF"
 
@@ -91,7 +91,7 @@ func NewService(db *reform.DB, pmmVersion string) *Service {
 		start:        time.Now(),
 		l:            l,
 		v1URL:        defaultV1URL,
-		v2Host:       defaultV2Host,
+		v2Host:       "",
 		interval:     defaultInterval,
 		retryBackoff: defaultRetryBackoff,
 		retryCount:   defaultRetryCount,
@@ -103,10 +103,7 @@ func NewService(db *reform.DB, pmmVersion string) *Service {
 		l.Warnf("v1URL changed to %q.", u)
 		s.v1URL = u
 	}
-	if h := os.Getenv(envV2Host); h != "" {
-		l.Warnf("v2Host changed to %q.", h)
-		s.v2Host = h
-	}
+	s.v2Host = envvars.GetSAASHost()
 	if d, err := time.ParseDuration(os.Getenv(envInterval)); err == nil && d > 0 {
 		l.Warnf("Interval changed to %s.", d)
 		s.interval = d

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -30,8 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/percona/pmm-managed/utils/envvars"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
@@ -47,6 +45,7 @@ import (
 	"gopkg.in/reform.v1"
 
 	"github.com/percona/pmm-managed/models"
+	"github.com/percona/pmm-managed/utils/envvars"
 )
 
 const (

--- a/utils/envvars/parser.go
+++ b/utils/envvars/parser.go
@@ -149,13 +149,17 @@ func parseStringDuration(value string) (time.Duration, error) {
 	return d, nil
 }
 
+// GetSAASHost validates PERCONA_TEST_SAAS_HOST env variable.
+// returns it if it's valid, otherwise returns defaultSAASHost.
 func GetSAASHost() string {
 	h := os.Getenv(envSAASHost)
 	if govalidator.IsURL(h) {
 		logrus.Warnf("SAAS host changed to %s.", h)
+
 		return h
 	}
 	logrus.Infof("Using default SAAS host %s.", defaultSAASHost)
+
 	return defaultSAASHost
 }
 


### PR DESCRIPTION
created a shared func to validate and get SAAS host, panic when old SAAS env variables are passed

[SAAS-321](https://jira.percona.com/browse/SAAS-321)

- [ ] Build: https://github.com/Percona-Lab/pmm-submodules/pull/0

- [ ] Links to other linked pull requests (optional).
---
- [ ] Tests passed.
- [ ] Feature build pass.
- [ ] (Re)requested review.
- [ ] Fix conflicts with target branch.
- [ ] Update API dependency.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.
