### PR TITLE
SAAS-372 pmm-managed-starlark: Increase memory limit to 1GB

### DIFF
--- a/cmd/pmm-managed-starlark/main.go
+++ b/cmd/pmm-managed-starlark/main.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	cpuLimit         = 4 * time.Second
-	memoryLimitBytes = 100 * 1024 * 1024
+	memoryLimitBytes = 1024 * 1024 * 1024
 
 	// only used for testing.
 	starlarkRecursionFlag = "PERCONA_TEST_STARLARK_ALLOW_RECURSION"


### PR DESCRIPTION
The previous 100MB limit was causing intermittent errors "cannot allocate memory", for now we will bump the limit up to 1GB [link to slack conversation](https://percona.slack.com/archives/GV9GJJY77/p1601899214121300) and solve the problem later as a part of SAAS-372
