### PR TITLE
Merge prometheus package into victoriametrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 [![CLA assistant](https://cla-assistant.percona.com/readme/badge/percona/pmm-managed)](https://cla-assistant.percona.com/percona/pmm-managed)
 
 pmm-managed manages configuration of [PMM](https://www.percona.com/doc/percona-monitoring-and-management/index.html)
-server components (Prometheus, Grafana, etc.) and exposes API for that. Those APIs are used by
+server components (VictoriaMetrics, Grafana, etc.) and exposes API for that. Those APIs are used by
 [pmm-admin tool](https://github.com/percona/pmm-admin).

--- a/main.go
+++ b/main.go
@@ -76,7 +76,6 @@ import (
 	managementgrpc "github.com/percona/pmm-managed/services/management/grpc"
 	"github.com/percona/pmm-managed/services/management/ia"
 	"github.com/percona/pmm-managed/services/platform"
-	"github.com/percona/pmm-managed/services/prometheus"
 	"github.com/percona/pmm-managed/services/qan"
 	"github.com/percona/pmm-managed/services/server"
 	"github.com/percona/pmm-managed/services/supervisord"
@@ -587,7 +586,7 @@ func main() {
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reformL)
 
 	cleaner := clean.New(db)
-	alertingRules := prometheus.NewAlertingRules()
+	alertingRules := victoriametrics.NewAlertingRules()
 
 	vmParams, err := models.NewVictoriaMetricsParams(victoriametrics.BasePrometheusConfigPath)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -64,9 +64,7 @@ func TestImports(t *testing.T) {
 		"github.com/percona/pmm-managed/services/server",
 		"github.com/percona/pmm-managed/services/supervisord",
 		"github.com/percona/pmm-managed/services/telemetry",
-
-		// TODO add "github.com/percona/pmm-managed/services/victoriametrics" once we remove prometheus package
-		"github.com/percona/pmm-managed/services/prometheus",
+		"github.com/percona/pmm-managed/services/victoriametrics",
 	} {
 		constraints[service] = constraint{
 			blacklistPrefixes: []string{

--- a/models/agent_model.go
+++ b/models/agent_model.go
@@ -32,7 +32,7 @@ import (
 //go:generate reform
 
 // AgentType represents Agent type as stored in databases:
-// pmm-managed's PostgreSQL, qan-api's ClickHouse, and Prometheus.
+// pmm-managed's PostgreSQL, qan-api's ClickHouse, and VictoriaMetrics.
 type AgentType string
 
 // Agent types (in the same order as in agents.proto).

--- a/models/node_model.go
+++ b/models/node_model.go
@@ -26,7 +26,7 @@ import (
 //go:generate reform
 
 // NodeType represents Node type as stored in databases:
-// pmm-managed's PostgreSQL, qan-api's ClickHouse, and Prometheus.
+// pmm-managed's PostgreSQL, qan-api's ClickHouse, and VictoriaMetrics.
 type NodeType string
 
 // Node types (in the same order as in nodes.proto).

--- a/models/service_model.go
+++ b/models/service_model.go
@@ -25,7 +25,7 @@ import (
 //go:generate reform
 
 // ServiceType represents Service type as stored in databases:
-// pmm-managed's PostgreSQL, qan-api's ClickHouse, and Prometheus.
+// pmm-managed's PostgreSQL, qan-api's ClickHouse, and VictoriaMetrics.
 type ServiceType string
 
 // Service types (in the same order as in services.proto).

--- a/models/settings.go
+++ b/models/settings.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 )
 
-// MetricsResolutions contains standard Prometheus metrics resolutions.
+// MetricsResolutions contains standard VictoriaMetrics metrics resolutions.
 type MetricsResolutions struct {
 	HR time.Duration `json:"hr"`
 	MR time.Duration `json:"mr"`

--- a/packages.dot
+++ b/packages.dot
@@ -13,7 +13,6 @@ digraph packages {
 	"/" -> "/services/management/grpc";
 	"/" -> "/services/management/ia";
 	"/" -> "/services/platform";
-	"/" -> "/services/prometheus";
 	"/" -> "/services/qan";
 	"/" -> "/services/server";
 	"/" -> "/services/supervisord";
@@ -38,11 +37,9 @@ digraph packages {
 	"/services/management/grpc" -> "/services/agents";
 	"/services/management/grpc" -> "/services/grafana";
 	"/services/management/grpc" -> "/services/management";
-	"/services/prometheus" -> "/models";
 	"/services/qan" -> "/models";
 	"/services/server" -> "/models";
 	"/services/supervisord" -> "/models";
 	"/services/telemetry" -> "/models";
 	"/services/victoriametrics" -> "/models";
-	"/services/victoriametrics" -> "/services/prometheus";
 }

--- a/services/victoriametrics/alerting_rules.go
+++ b/services/victoriametrics/alerting_rules.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-package prometheus
+package victoriametrics
 
 import (
 	"bytes"

--- a/services/victoriametrics/alerting_rules_test.go
+++ b/services/victoriametrics/alerting_rules_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-package prometheus
+package victoriametrics
 
 import (
 	"context"

--- a/services/victoriametrics/prometheus.go
+++ b/services/victoriametrics/prometheus.go
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// Package prometheus contains business logic of working with Prometheus.
-package prometheus
+package victoriametrics
 
 import (
 	"github.com/AlekSi/pointer"

--- a/services/victoriametrics/scrape_configs.go
+++ b/services/victoriametrics/scrape_configs.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-package prometheus
+package victoriametrics
 
 import (
 	"fmt"

--- a/services/victoriametrics/scrape_configs_test.go
+++ b/services/victoriametrics/scrape_configs_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-package prometheus
+package victoriametrics
 
 import (
 	"net/url"

--- a/services/victoriametrics/victoriametrics.go
+++ b/services/victoriametrics/victoriametrics.go
@@ -40,7 +40,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/percona/pmm-managed/models"
-	"github.com/percona/pmm-managed/services/prometheus"
 )
 
 const (
@@ -228,11 +227,11 @@ func (svc *Service) marshalConfig() ([]byte, error) {
 			cfg.GlobalConfig.ScrapeInterval = config.Duration(s.LR)
 		}
 		if cfg.GlobalConfig.ScrapeTimeout == 0 {
-			cfg.GlobalConfig.ScrapeTimeout = prometheus.ScrapeTimeout(s.LR)
+			cfg.GlobalConfig.ScrapeTimeout = ScrapeTimeout(s.LR)
 		}
 		cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, scrapeConfigForVictoriaMetrics(s.HR), scrapeConfigForVMAlert(s.HR))
-		prometheus.AddInternalServicesToScrape(cfg, s, settings.DBaaS.Enabled)
-		return prometheus.AddScrapeConfigs(svc.l, cfg, tx.Querier, &s, nil, false)
+		AddInternalServicesToScrape(cfg, s, settings.DBaaS.Enabled)
+		return AddScrapeConfigs(svc.l, cfg, tx.Querier, &s, nil, false)
 	})
 	if e != nil {
 		return nil, e
@@ -333,7 +332,7 @@ func scrapeConfigForVictoriaMetrics(interval time.Duration) *config.ScrapeConfig
 	return &config.ScrapeConfig{
 		JobName:        "victoriametrics",
 		ScrapeInterval: config.Duration(interval),
-		ScrapeTimeout:  prometheus.ScrapeTimeout(interval),
+		ScrapeTimeout:  ScrapeTimeout(interval),
 		MetricsPath:    "/prometheus/metrics",
 		ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
 			StaticConfigs: []*config.Group{
@@ -351,7 +350,7 @@ func scrapeConfigForVMAlert(interval time.Duration) *config.ScrapeConfig {
 	return &config.ScrapeConfig{
 		JobName:        "vmalert",
 		ScrapeInterval: config.Duration(interval),
-		ScrapeTimeout:  prometheus.ScrapeTimeout(interval),
+		ScrapeTimeout:  ScrapeTimeout(interval),
 		MetricsPath:    "/metrics",
 		ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
 			StaticConfigs: []*config.Group{
@@ -373,7 +372,7 @@ func (svc *Service) BuildScrapeConfigForVMAgent(pmmAgentID string) ([]byte, erro
 			return err
 		}
 		s := settings.MetricsResolutions
-		return prometheus.AddScrapeConfigs(svc.l, &cfg, tx.Querier, &s, pointer.ToString(pmmAgentID), true)
+		return AddScrapeConfigs(svc.l, &cfg, tx.Querier, &s, pointer.ToString(pmmAgentID), true)
 	})
 	if e != nil {
 		return nil, e

--- a/services/victoriametrics/vmalert.go
+++ b/services/victoriametrics/vmalert.go
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// Package victoriametrics provides facilities for working with VMAlert.
 package victoriametrics
 
 import (
@@ -29,14 +28,13 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/percona/pmm-managed/models"
-	"github.com/percona/pmm-managed/services/prometheus"
 )
 
 // VMAlert is responsible for interactions with victoria metrics.
 type VMAlert struct {
 	baseURL             *url.URL
 	client              *http.Client
-	alertingRules       *prometheus.AlertingRules
+	alertingRules       *AlertingRules
 	cachedAlertingRules string
 
 	l    *logrus.Entry
@@ -44,7 +42,7 @@ type VMAlert struct {
 }
 
 // NewVMAlert creates new Victoria Metrics Alert service.
-func NewVMAlert(alertRules *prometheus.AlertingRules, baseURL string, params *models.VictoriaMetricsParams) (*VMAlert, error) {
+func NewVMAlert(alertRules *AlertingRules, baseURL string, params *models.VictoriaMetricsParams) (*VMAlert, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/services/victoriametrics/vmalert_test.go
+++ b/services/victoriametrics/vmalert_test.go
@@ -29,17 +29,16 @@ import (
 	"gopkg.in/reform.v1/dialects/postgresql"
 
 	"github.com/percona/pmm-managed/models"
-	"github.com/percona/pmm-managed/services/prometheus"
 	"github.com/percona/pmm-managed/utils/testdb"
 )
 
-func setupVMAlert(t *testing.T) (*reform.DB, *prometheus.AlertingRules, *VMAlert) {
+func setupVMAlert(t *testing.T) (*reform.DB, *AlertingRules, *VMAlert) {
 	t.Helper()
 	check := require.New(t)
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 
-	rules := prometheus.NewAlertingRules()
+	rules := NewAlertingRules()
 	vmParams := &models.VictoriaMetricsParams{}
 	svc, err := NewVMAlert(rules, "http://127.0.0.1:8880/", vmParams)
 	check.NoError(err)
@@ -50,7 +49,7 @@ func setupVMAlert(t *testing.T) (*reform.DB, *prometheus.AlertingRules, *VMAlert
 	return db, rules, svc
 }
 
-func teardownVMAlert(t *testing.T, rules *prometheus.AlertingRules, db *reform.DB) {
+func teardownVMAlert(t *testing.T, rules *AlertingRules, db *reform.DB) {
 	t.Helper()
 	check := assert.New(t)
 


### PR DESCRIPTION
With only a minimal refactoring. In particular, many methods should be un-exported now, but that is delayed to make diff smaller.