### PR TITLE
PMM-6891 Extract alerting rule validation function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,9 +29,13 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    # we don't use Go 1.13 errors wrapping yet
+    - errorlint
+    - goerr113
+    - wrapcheck
+
     - exhaustivestruct  # useless
     - gochecknoglobals  # mostly useless
-    - goerr113          # we use different approach for errors
     - gomnd             # we are using numbers in many cases
     - gomodguard        # we are not using modules
     - nlreturn          # too annoying

--- a/main_test.go
+++ b/main_test.go
@@ -89,6 +89,13 @@ func TestImports(t *testing.T) {
 		}
 	}
 
+	// validators should not import gRPC stack, including errors
+	constraints["github.com/percona/pmm-managed/utils/validators"] = constraint{
+		blacklistPrefixes: []string{
+			"google.golang.org/grpc",
+		},
+	}
+
 	// just to add them to packages.dot
 	for _, service := range []string{
 		"github.com/percona/pmm-managed",
@@ -97,9 +104,6 @@ func TestImports(t *testing.T) {
 		"github.com/percona/pmm-managed/services/agents/grpc",
 		"github.com/percona/pmm-managed/services/inventory/grpc",
 		"github.com/percona/pmm-managed/services/management/grpc",
-
-		// TODO remove from the once we add it above
-		"github.com/percona/pmm-managed/services/victoriametrics",
 	} {
 		constraints[service] = constraint{}
 	}

--- a/services/vmalert/alerting_rules.go
+++ b/services/vmalert/alerting_rules.go
@@ -17,18 +17,12 @@
 package vmalert
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"strings"
-	"time"
 
-	"github.com/percona/pmm/utils/pdeathsig"
-	"github.com/pkg/errors"
+	"github.com/percona/pmm-managed/utils/validators"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -49,38 +43,11 @@ func NewAlertingRules() *AlertingRules {
 
 // ValidateRules validates alerting rules.
 func (s *AlertingRules) ValidateRules(ctx context.Context, rules string) error {
-	tempFile, err := ioutil.TempFile("", "temp_rules_*.yml")
-	if err != nil {
-		return errors.WithStack(err)
+	err := validators.ValidateAlertingRules(ctx, rules)
+	if e, ok := err.(*validators.InvalidAlertingRuleError); ok {
+		return status.Errorf(codes.InvalidArgument, e.Msg)
 	}
-	tempFile.Close()                 //nolint:errcheck
-	defer os.Remove(tempFile.Name()) //nolint:errcheck
-
-	if err = ioutil.WriteFile(tempFile.Name(), []byte(rules), 0644); err != nil {
-		return errors.WithStack(err)
-	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(timeoutCtx, "vmalert", "-dryRun", "-rule", tempFile.Name()) //nolint:gosec
-	pdeathsig.Set(cmd, unix.SIGKILL)
-
-	b, err := cmd.CombinedOutput()
-	if err != nil {
-		if e, ok := err.(*exec.ExitError); ok && e.ExitCode() != 0 {
-			s.l.Infof("%s: %s\n%s", strings.Join(cmd.Args, " "), e, b)
-			return status.Errorf(codes.InvalidArgument, "Invalid alerting rules.")
-		}
-		return errors.WithStack(err)
-	}
-
-	if bytes.Contains(b, []byte("SUCCESS: 0 rules found")) {
-		return status.Errorf(codes.InvalidArgument, "Zero alerting rules found.")
-	}
-
-	s.l.Debugf("%q check passed.", strings.Join(cmd.Args, " "))
-	return nil
+	return err
 }
 
 // ReadRules reads current rules from FS.
@@ -99,5 +66,5 @@ func (s *AlertingRules) RemoveRulesFile() error {
 
 // WriteRules writes rules to file.
 func (s *AlertingRules) WriteRules(rules string) error {
-	return ioutil.WriteFile(alertingRulesFile, []byte(rules), 0644)
+	return ioutil.WriteFile(alertingRulesFile, []byte(rules), 0o644) //nolint:gosec
 }

--- a/services/vmalert/alerting_rules.go
+++ b/services/vmalert/alerting_rules.go
@@ -21,10 +21,11 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/percona/pmm-managed/utils/validators"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/percona/pmm-managed/utils/validators"
 )
 
 const alertingRulesFile = "/srv/prometheus/rules/pmm.rules.yml"

--- a/utils/validators/alerting_rules.go
+++ b/utils/validators/alerting_rules.go
@@ -1,0 +1,76 @@
+// pmm-managed
+// Copyright (C) 2017 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package validators
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/percona/pmm/utils/pdeathsig"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// InvalidAlertingRuleError represents "normal" alerting rule validation error.
+type InvalidAlertingRuleError struct {
+	Msg string
+}
+
+// Error implements error interface.
+func (e *InvalidAlertingRuleError) Error() string {
+	return e.Msg
+}
+
+// ValidateAlertingRules validates alerting rules (https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+// by storing them in temporary file and calling `vmalert -dryRun -rule`.
+// Returned error is nil, *InvalidAlertingRuleError for "normal" validation errors,
+// or some other fatal error.
+func ValidateAlertingRules(ctx context.Context, rules string) error {
+	tempFile, err := ioutil.TempFile("", "temp_rules_*.yml")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	tempFile.Close()                 //nolint:errcheck
+	defer os.Remove(tempFile.Name()) //nolint:errcheck
+
+	if err = ioutil.WriteFile(tempFile.Name(), []byte(rules), 0o644); err != nil { //nolint:gosec
+		return errors.WithStack(err)
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(timeoutCtx, "vmalert", "-loggerLevel", "WARN", "-dryRun", "-rule", tempFile.Name()) //nolint:gosec
+	pdeathsig.Set(cmd, unix.SIGKILL)
+
+	b, err := cmd.CombinedOutput()
+	logrus.Debugf("ValidateAlertingRules: %v\n%s", err, b)
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok && e.ExitCode() != 0 {
+			return &InvalidAlertingRuleError{
+				Msg: "Invalid alerting rules.",
+			}
+		}
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/utils/validators/validators.go
+++ b/utils/validators/validators.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// Package validators contains settings validators.
+// Package validators contains various validators.
 package validators
 
 import (


### PR DESCRIPTION
We need it for both integrated and external alerting, but `vmalert.AlertingRules` is very external-specific.

[PMM-6891](https://jira.percona.com/browse/PMM-6891)

- [ ] Build: https://github.com/Percona-Lab/pmm-submodules/pull/1274

- [ ] Links to other linked pull requests (optional).
---
- [ ] Tests passed.
- [ ] Feature build pass.
- [ ] (Re)requested review.
- [ ] Fix conflicts with target branch.
- [ ] Update API dependency.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.
