### PR TITLE
Exclude test db from pg exporter

### DIFF
--- a/services/agents/postgresql.go
+++ b/services/agents/postgresql.go
@@ -48,7 +48,7 @@ func postgresExporterConfig(service *models.Service, exporter *models.Agent, red
 		"--collect.custom_query.hr.directory=/usr/local/percona/pmm2/collectors/custom-queries/postgresql/high-resolution",
 
 		"--auto-discover-databases",
-		"--exclude-databases=template0,template1,postgres",
+		"--exclude-databases=template0,template1,postgres,pmm-managed-dev",
 		"--web.listen-address=:" + tdp.Left + " .listen_port " + tdp.Right,
 	}
 

--- a/services/agents/postgresql_test.go
+++ b/services/agents/postgresql_test.go
@@ -52,7 +52,7 @@ func TestPostgresExporterConfig(t *testing.T) {
 			"--collect.custom_query.lr.directory=/usr/local/percona/pmm2/collectors/custom-queries/postgresql/low-resolution",
 			"--collect.custom_query.mr",
 			"--collect.custom_query.mr.directory=/usr/local/percona/pmm2/collectors/custom-queries/postgresql/medium-resolution",
-			"--exclude-databases=template0,template1,postgres",
+			"--exclude-databases=template0,template1,postgres,pmm-managed-dev",
 			"--web.listen-address=:{{ .listen_port }}",
 		},
 		Env: []string{
@@ -102,7 +102,7 @@ func TestPostgresExporterConfig(t *testing.T) {
 				"--collect.custom_query.lr.directory=/usr/local/percona/pmm2/collectors/custom-queries/postgresql/low-resolution",
 				"--collect.custom_query.mr",
 				"--collect.custom_query.mr.directory=/usr/local/percona/pmm2/collectors/custom-queries/postgresql/medium-resolution",
-				"--exclude-databases=template0,template1,postgres",
+				"--exclude-databases=template0,template1,postgres,pmm-managed-dev",
 				"--web.listen-address=:{{ .listen_port }}",
 			},
 		}


### PR DESCRIPTION
After `auto-discover-databases` flag was added to the postgresql-exporter tests start failing with `pq: database "pmm-managed-dev" is being accessed by other users` error. So as temporary solution we can exclude our test db from discovery.

That PR CI fails because it uses previous image of PMM server.

---
- [ ] Tests passed.
- [ ] Feature build pass.
- [ ] (Re)requested review.
- [ ] Fix conflicts with target branch.
- [ ] Update API dependency.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.