### PR TITLE
DLV Debugger

### DIFF
--- a/Makefile.devcontainer
+++ b/Makefile.devcontainer
@@ -45,6 +45,11 @@ install-race:                   ## Install pmm-managed binaries with race detect
 	go build -race -v $(PMM_LD_FLAGS) -o $(PMM_RELEASE_PATH)/pmm-managed-init ./cmd/pmm-managed-init
 	go build -race -v $(PMM_LD_FLAGS) -o $(PMM_RELEASE_PATH)/pmm-managed-starlark ./cmd/pmm-managed-starlark
 
+install-debug:  ## Install pmm-managed binaries with debug symbols.
+	go build -gcflags="all=-N -l" -v $(PMM_LD_FLAGS) -o $(PMM_RELEASE_PATH)/pmm-managed
+	go build -gcflags="all=-N -l" -v $(PMM_LD_FLAGS) -o $(PMM_RELEASE_PATH)/pmm-managed-init ./cmd/pmm-managed-init
+	go build -gcflags="all=-N -l" -v $(PMM_LD_FLAGS) -o $(PMM_RELEASE_PATH)/pmm-managed-starlark ./cmd/pmm-managed-starlark
+
 PMM_TEST_PACKAGES ?= ./...
 PMM_TEST_FLAGS ?= -timeout=90s
 PMM_TEST_RUN_UPDATE ?= 0
@@ -92,6 +97,8 @@ _run:
 run: install _run               ## Run pmm-managed.
 
 run-race: install-race _run     ## Run pmm-managed with race detector.
+
+run-debug: install-debug _run               ## Run pmm-managed with debug symbols.
 
 # TODO https://jira.percona.com/browse/PMM-3484, see maincover_test.go
 # run-race-cover: install-race    ## Run pmm-managed with race detector and collect coverage information.

--- a/Makefile.devcontainer
+++ b/Makefile.devcontainer
@@ -33,7 +33,7 @@ init:                   ## Install development tools
 
 
 install:                        ## Install pmm-managed binaries.
-	go install -v $(PMM_LD_FLAGS) ./...
+	go install -gcflags="all=-N -l" -v $(PMM_LD_FLAGS) ./...
 
 	make release
 
@@ -117,3 +117,6 @@ travis: ci-reviewdog test-race test-cover test-crosscover
 ci-reviewdog:
 	golangci-lint run -c=.golangci-required.yml --out-format=line-number | reviewdog -f=golangci-lint -level=error -reporter=github-pr-check
 	golangci-lint run -c=.golangci.yml --out-format=line-number | reviewdog -f=golangci-lint -level=error -reporter=github-pr-review
+
+dlv/attach:
+	dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient attach $(shell pgrep pmm-managed)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     ports:
       - 127.0.0.1:80:80
       - 443:443
+      # For headless delve
+      - 2345:2345
     volumes:
       - .:/root/go/src/github.com/percona/pmm-managed
       - ./Makefile.devcontainer:/root/go/src/github.com/percona/pmm-managed/Makefile:ro


### PR DESCRIPTION
Dev command for attaching delve
Compile pmm-managed with extra debug flags

I'm not sure about `make install`:
It does `go install` with debugging flags
But then make release
Which creates binaries to PMM_RELEASE_PATH. But `make run` copy binary from this PMM_RELEASE_PATH, copy to /sbin and run it.
So I think, we don't use then binary with these extra flags