### PR TITLE
PMM-8145 Update scrape timeout for RDS

### DIFF
--- a/services/victoriametrics/scrape_configs.go
+++ b/services/victoriametrics/scrape_configs.go
@@ -46,17 +46,6 @@ func scrapeTimeout(interval time.Duration) config.Duration {
 	case interval <= 10*time.Second:
 		return config.Duration(interval - time.Second)
 	default:
-		return config.Duration(10 * time.Second)
-	}
-}
-
-// scrapeTimeoutRemote returns default scrape timeout for given scrape interval for remote instances.
-// This is different from scrapeTimeout because due to network latencies, this has to be higher.
-func scrapeTimeoutRemote(interval time.Duration) config.Duration {
-	switch {
-	case interval <= 2*time.Second:
-		return config.Duration(time.Second)
-	default:
 		return config.Duration(float64(interval) * 0.9)
 	}
 }
@@ -218,7 +207,7 @@ func scrapeConfigForRDSExporter(intervalName string, interval time.Duration, hos
 	return &config.ScrapeConfig{
 		JobName:        jobName,
 		ScrapeInterval: config.Duration(interval),
-		ScrapeTimeout:  scrapeTimeoutRemote(interval),
+		ScrapeTimeout:  scrapeTimeout(interval),
 		MetricsPath:    metricsPath,
 		HonorLabels:    true,
 		ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{

--- a/services/victoriametrics/scrape_configs.go
+++ b/services/victoriametrics/scrape_configs.go
@@ -50,6 +50,17 @@ func scrapeTimeout(interval time.Duration) config.Duration {
 	}
 }
 
+// scrapeTimeoutRemote returns default scrape timeout for given scrape interval for remote instances.
+// This is different from scrapeTimeout because due to network latencies, this has to be higher.
+func scrapeTimeoutRemote(interval time.Duration) config.Duration {
+	switch {
+	case interval <= 2*time.Second:
+		return config.Duration(time.Second)
+	default:
+		return config.Duration(float64(interval) * 0.9)
+	}
+}
+
 func scrapeConfigForAlertmanager(interval time.Duration) *config.ScrapeConfig {
 	return &config.ScrapeConfig{
 		JobName:        "alertmanager",
@@ -207,7 +218,7 @@ func scrapeConfigForRDSExporter(intervalName string, interval time.Duration, hos
 	return &config.ScrapeConfig{
 		JobName:        jobName,
 		ScrapeInterval: config.Duration(interval),
-		ScrapeTimeout:  scrapeTimeout(interval),
+		ScrapeTimeout:  scrapeTimeoutRemote(interval),
 		MetricsPath:    metricsPath,
 		HonorLabels:    true,
 		ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{

--- a/services/victoriametrics/scrape_configs_test.go
+++ b/services/victoriametrics/scrape_configs_test.go
@@ -1023,7 +1023,7 @@ func TestScrapeConfig(t *testing.T) {
 			expected := []*config.ScrapeConfig{{
 				JobName:        "rds_exporter_1_1_1_1_12345_mr-5s",
 				ScrapeInterval: config.Duration(s.MR),
-				ScrapeTimeout:  scrapeTimeoutRemote(s.MR),
+				ScrapeTimeout:  scrapeTimeout(s.MR),
 				MetricsPath:    "/enhanced",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1034,7 +1034,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_1_1_1_1_12345_lr-1m0s",
 				ScrapeInterval: config.Duration(s.LR),
-				ScrapeTimeout:  scrapeTimeoutRemote(s.LR),
+				ScrapeTimeout:  scrapeTimeout(s.LR),
 				MetricsPath:    "/basic",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1045,7 +1045,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12345_mr-5s",
 				ScrapeInterval: config.Duration(s.MR),
-				ScrapeTimeout:  scrapeTimeoutRemote(s.MR),
+				ScrapeTimeout:  scrapeTimeout(s.MR),
 				MetricsPath:    "/enhanced",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1056,7 +1056,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12345_lr-1m0s",
 				ScrapeInterval: config.Duration(s.LR),
-				ScrapeTimeout:  scrapeTimeoutRemote(s.LR),
+				ScrapeTimeout:  scrapeTimeout(s.LR),
 				MetricsPath:    "/basic",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1067,7 +1067,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12346_mr-5s",
 				ScrapeInterval: config.Duration(s.MR),
-				ScrapeTimeout:  scrapeTimeoutRemote(s.MR),
+				ScrapeTimeout:  scrapeTimeout(s.MR),
 				MetricsPath:    "/enhanced",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1078,7 +1078,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12346_lr-1m0s",
 				ScrapeInterval: config.Duration(s.LR),
-				ScrapeTimeout:  scrapeTimeoutRemote(s.LR),
+				ScrapeTimeout:  scrapeTimeout(s.LR),
 				MetricsPath:    "/basic",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{

--- a/services/victoriametrics/scrape_configs_test.go
+++ b/services/victoriametrics/scrape_configs_test.go
@@ -1023,7 +1023,7 @@ func TestScrapeConfig(t *testing.T) {
 			expected := []*config.ScrapeConfig{{
 				JobName:        "rds_exporter_1_1_1_1_12345_mr-5s",
 				ScrapeInterval: config.Duration(s.MR),
-				ScrapeTimeout:  scrapeTimeout(s.MR),
+				ScrapeTimeout:  scrapeTimeoutRemote(s.MR),
 				MetricsPath:    "/enhanced",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1034,7 +1034,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_1_1_1_1_12345_lr-1m0s",
 				ScrapeInterval: config.Duration(s.LR),
-				ScrapeTimeout:  scrapeTimeout(s.LR),
+				ScrapeTimeout:  scrapeTimeoutRemote(s.LR),
 				MetricsPath:    "/basic",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1045,7 +1045,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12345_mr-5s",
 				ScrapeInterval: config.Duration(s.MR),
-				ScrapeTimeout:  scrapeTimeout(s.MR),
+				ScrapeTimeout:  scrapeTimeoutRemote(s.MR),
 				MetricsPath:    "/enhanced",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1056,7 +1056,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12345_lr-1m0s",
 				ScrapeInterval: config.Duration(s.LR),
-				ScrapeTimeout:  scrapeTimeout(s.LR),
+				ScrapeTimeout:  scrapeTimeoutRemote(s.LR),
 				MetricsPath:    "/basic",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1067,7 +1067,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12346_mr-5s",
 				ScrapeInterval: config.Duration(s.MR),
-				ScrapeTimeout:  scrapeTimeout(s.MR),
+				ScrapeTimeout:  scrapeTimeoutRemote(s.MR),
 				MetricsPath:    "/enhanced",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -1078,7 +1078,7 @@ func TestScrapeConfig(t *testing.T) {
 			}, {
 				JobName:        "rds_exporter_2_2_2_2_12346_lr-1m0s",
 				ScrapeInterval: config.Duration(s.LR),
-				ScrapeTimeout:  scrapeTimeout(s.LR),
+				ScrapeTimeout:  scrapeTimeoutRemote(s.LR),
 				MetricsPath:    "/basic",
 				HonorLabels:    true,
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{

--- a/services/victoriametrics/victoriametrics_test.go
+++ b/services/victoriametrics/victoriametrics_test.go
@@ -190,7 +190,7 @@ func TestVictoriaMetrics(t *testing.T) {
 ---
 global:
     scrape_interval: 1m
-    scrape_timeout: 10s
+    scrape_timeout: 54s
 scrape_configs:
     - job_name: victoriametrics
       honor_timestamps: false
@@ -339,7 +339,7 @@ scrape_configs:
             - perf_schema.indexiowaits
             - perf_schema.tableiowaits
       scrape_interval: 1m
-      scrape_timeout: 10s
+      scrape_timeout: 54s
       metrics_path: /metrics
       static_configs:
         - targets:
@@ -447,7 +447,7 @@ scrape_configs:
             - perf_schema.indexiowaits
             - perf_schema.tableiowaits
       scrape_interval: 1m
-      scrape_timeout: 10s
+      scrape_timeout: 54s
       metrics_path: /metrics
       static_configs:
         - targets:
@@ -531,7 +531,7 @@ scrape_configs:
         collect[]:
             - custom_query.lr
       scrape_interval: 1m
-      scrape_timeout: 10s
+      scrape_timeout: 54s
       metrics_path: /metrics
       static_configs:
         - targets:
@@ -568,7 +568,7 @@ func TestConfigReload(t *testing.T) {
 ---
 global:
   scrape_interval: 1m
-  scrape_timeout: 10s
+  scrape_timeout: 54s
 scrape_configs:
 - job_name: victoriametrics
   honor_timestamps: false
@@ -614,7 +614,7 @@ scrape_configs:
 ---
 global:
   scrape_interval: 1m
-  scrape_timeout: 10s
+  scrape_timeout: 54s
 remote_write:
 - url: http://some-remote-url
 remote_read:

--- a/testdata/victoriametrics/promscrape.yml
+++ b/testdata/victoriametrics/promscrape.yml
@@ -2,7 +2,7 @@
 ---
 global:
     scrape_interval: 1m
-    scrape_timeout: 10s
+    scrape_timeout: 54s
 scrape_configs:
     - job_name: victoriametrics
       honor_timestamps: false


### PR DESCRIPTION
[PMM-8145 Remote PostgreSQL instance is not displayed on dashboards (OVF) ](https://jira.percona.com/browse/PMM-8145)

- [ ] Build: https://github.com/Percona-Lab/pmm-submodules/pull/1807

---
- [ ] Tests passed.
- [ ] Feature build pass.
- [ ] (Re)requested review.

**DRAFT** because we need the feasture build to test before we decide to merge this. 