### PR TITLE
PMM-8116 New metrics for pg_stat_monitor 0.9.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.10
 	github.com/percona-platform/dbaas-api v0.0.0-20210518140815-21d371355e30
 	github.com/percona-platform/saas v0.0.0-20210505183502-c18b6f47c932
-	github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1
+	github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a
 	github.com/percona/promconfig v0.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/percona-platform/dbaas-api v0.0.0-20210518140815-21d371355e30
 	github.com/percona-platform/saas v0.0.0-20210505183502-c18b6f47c932
-	github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible
+	github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e
 	github.com/percona/promconfig v0.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.10
 	github.com/percona-platform/dbaas-api v0.0.0-20210518140815-21d371355e30
 	github.com/percona-platform/saas v0.0.0-20210505183502-c18b6f47c932
-	github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a
+	github.com/percona/pmm v0.0.0-20210604063507-19bb5e017d33
 	github.com/percona/promconfig v0.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/percona-platform/dbaas-api v0.0.0-20210518140815-21d371355e30
 	github.com/percona-platform/saas v0.0.0-20210505183502-c18b6f47c932
-	github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e
+	github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1
 	github.com/percona/promconfig v0.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.10
 	github.com/percona-platform/dbaas-api v0.0.0-20210518140815-21d371355e30
 	github.com/percona-platform/saas v0.0.0-20210505183502-c18b6f47c932
-	github.com/percona/pmm v0.0.0-20210604063507-19bb5e017d33
+	github.com/percona/pmm v0.0.0-20210611190936-96a88244ad87
 	github.com/percona/promconfig v0.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,8 @@ github.com/percona/pmm v0.0.0-20210531122949-7658155fb62d h1:0in2OYNpL7pzDMq15Qs
 github.com/percona/pmm v0.0.0-20210531122949-7658155fb62d/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e h1:ru+lAacqQmZcbJpoR/paFDu2QKnJSeLyMkk8KbPowZg=
 github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
+github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1 h1:F23oTYtm6vM9RAcB78+3QbOPCysejwaOF9qarwtTqk8=
+github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible h1:CvT99p/A1qnFlffIKWqJ7i5zjVb5BxiWydWXQdtLm4Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/pmm v2.17.1-0.20210531071918-82b04079038d+incompatible h1:Ajd0nMqeYtVRDuiWXju4Y2HgI8dwrwYpRNv9hS7okmM=

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a h1:Rc+26LFwM89qsjm7IF8
 github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v0.0.0-20210604063507-19bb5e017d33 h1:mdXPBz57wb0UmDciv9xdbRcvKNGT9D1YOWqldadz2j8=
 github.com/percona/pmm v0.0.0-20210604063507-19bb5e017d33/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
+github.com/percona/pmm v0.0.0-20210611190936-96a88244ad87 h1:sj+fkXvfVOiYPfVsw9p1LiJVR2Oh2SIpIolNgyCj850=
+github.com/percona/pmm v0.0.0-20210611190936-96a88244ad87/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible h1:CvT99p/A1qnFlffIKWqJ7i5zjVb5BxiWydWXQdtLm4Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/pmm v2.17.1-0.20210531071918-82b04079038d+incompatible h1:Ajd0nMqeYtVRDuiWXju4Y2HgI8dwrwYpRNv9hS7okmM=

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,14 @@ github.com/percona-platform/dbaas-api v0.0.0-20210518140815-21d371355e30 h1:Dczu
 github.com/percona-platform/dbaas-api v0.0.0-20210518140815-21d371355e30/go.mod h1:35XsODD/au51FcfaQ7IhW1uSe689IPyCjaWVMRTYweQ=
 github.com/percona-platform/saas v0.0.0-20210505183502-c18b6f47c932 h1:EDe5KfOdEoEBKg33BsFsMrdazZu8vaRj4fTKdg4zjCc=
 github.com/percona-platform/saas v0.0.0-20210505183502-c18b6f47c932/go.mod h1:jJRyGMxxDJaSiU7AaHNS+8j1TFQQhX6lcYp8s0t8Knc=
+github.com/percona/pmm v0.0.0-20210531122949-7658155fb62d h1:0in2OYNpL7pzDMq15QssESEntNEDYE/GbmYCsFJ8NEY=
+github.com/percona/pmm v0.0.0-20210531122949-7658155fb62d/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
+github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e h1:ru+lAacqQmZcbJpoR/paFDu2QKnJSeLyMkk8KbPowZg=
+github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible h1:CvT99p/A1qnFlffIKWqJ7i5zjVb5BxiWydWXQdtLm4Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
+github.com/percona/pmm v2.17.1-0.20210531071918-82b04079038d+incompatible h1:Ajd0nMqeYtVRDuiWXju4Y2HgI8dwrwYpRNv9hS7okmM=
+github.com/percona/pmm v2.17.1-0.20210531071918-82b04079038d+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/promconfig v0.2.1 h1:LBbCDSQRfy0aTHFJMgrVQIE2WvmPkMTkIoznTfBAvj8=
 github.com/percona/promconfig v0.2.1/go.mod h1:Y2uXi5QNk71+ceJHuI9poank+0S1kjxd3K105fXKVkg=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
@@ -449,6 +455,7 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
@@ -463,6 +470,7 @@ github.com/prometheus/client_model v0.2.1-0.20200623203004-60555c9708c7 h1:NkLt0
 github.com/prometheus/client_model v0.2.1-0.20200623203004-60555c9708c7/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
@@ -470,6 +478,7 @@ github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
@@ -633,6 +642,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -640,6 +650,7 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1 h1:F23oTYtm6vM9RAcB78+
 github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a h1:Rc+26LFwM89qsjm7IF84cU5U1T4gPSDcF57KA9ygqKI=
 github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
+github.com/percona/pmm v0.0.0-20210604063507-19bb5e017d33 h1:mdXPBz57wb0UmDciv9xdbRcvKNGT9D1YOWqldadz2j8=
+github.com/percona/pmm v0.0.0-20210604063507-19bb5e017d33/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible h1:CvT99p/A1qnFlffIKWqJ7i5zjVb5BxiWydWXQdtLm4Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/pmm v2.17.1-0.20210531071918-82b04079038d+incompatible h1:Ajd0nMqeYtVRDuiWXju4Y2HgI8dwrwYpRNv9hS7okmM=

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,8 @@ github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e h1:ru+lAacqQmZcbJpoR/p
 github.com/percona/pmm v0.0.0-20210531135037-60c83c954d9e/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1 h1:F23oTYtm6vM9RAcB78+3QbOPCysejwaOF9qarwtTqk8=
 github.com/percona/pmm v0.0.0-20210602064401-a0a0deb155f1/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
+github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a h1:Rc+26LFwM89qsjm7IF84cU5U1T4gPSDcF57KA9ygqKI=
+github.com/percona/pmm v0.0.0-20210602121240-1c61405de05a/go.mod h1:Cm2JKvJMlMimtAhmF/1BUvz3qVJZ2O2zxQXRvtQh93Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible h1:CvT99p/A1qnFlffIKWqJ7i5zjVb5BxiWydWXQdtLm4Q=
 github.com/percona/pmm v2.17.1-0.20210528151815-ff53d87f066b+incompatible/go.mod h1:nN14kK4Dfl2Ub1k05aOnAHv7SmLEQtCsYX+DEfLgrkU=
 github.com/percona/pmm v2.17.1-0.20210531071918-82b04079038d+incompatible h1:Ajd0nMqeYtVRDuiWXju4Y2HgI8dwrwYpRNv9hS7okmM=

--- a/services/qan/client.go
+++ b/services/qan/client.go
@@ -492,4 +492,13 @@ func fillPostgreSQL(mb *qanpb.MetricsBucket, bp *agentpb.MetricsBucket_PostgreSQ
 
 	mb.MCpuUserTimeCnt = bp.MCpuUserTimeCnt
 	mb.MCpuUserTimeSum = bp.MCpuUserTimeSum
+
+	mb.MPlansCallsCnt = bp.MPlansCallsCnt
+	mb.MPlansCallsSum = bp.MPlansCallsSum
+
+	mb.MWalRecordsCnt = bp.MWalRecordsCnt
+	mb.MWalRecordsSum = bp.MWalRecordsSum
+
+	mb.MWalFpiCnt = bp.MWalFpiCnt
+	mb.MWalFpiSum = bp.MWalFpiSum
 }

--- a/services/supervisord/devcontainer_test.go
+++ b/services/supervisord/devcontainer_test.go
@@ -52,7 +52,7 @@ func TestDevContainer(t *testing.T) {
 		assert.True(t, strings.HasPrefix(fullVersion, "2."), "%s", fullVersion)
 		require.NotEmpty(t, info.BuildTime)
 		assert.True(t, info.BuildTime.After(gaReleaseDate), "BuildTime = %s", info.BuildTime)
-		assert.Equal(t, "pmm2-server", info.Repo)
+		assert.Equal(t, "local", info.Repo)
 
 		info2 := checker.Installed(ctx)
 		assert.Equal(t, info, info2)
@@ -70,7 +70,7 @@ func TestDevContainer(t *testing.T) {
 		assert.True(t, strings.HasPrefix(installedFullVersion, "2."), "%s", installedFullVersion)
 		require.NotEmpty(t, res.Installed.BuildTime)
 		assert.True(t, res.Installed.BuildTime.After(gaReleaseDate), "Installed.BuildTime = %s", res.Installed.BuildTime)
-		assert.Equal(t, "pmm2-server", res.Installed.Repo)
+		assert.Equal(t, "local", res.Installed.Repo)
 
 		assert.True(t, strings.HasPrefix(res.Latest.Version, "2."), "%s", res.Latest.Version)
 		latestFullVersion, isFeatureBranch := normalizeFullversion(&res.Latest)
@@ -90,7 +90,7 @@ func TestDevContainer(t *testing.T) {
 		assert.Empty(t, res.LatestNewsURL, "latest_news_url should be empty")
 		assert.Equal(t, res.Installed, res.Latest, "version should be the same (latest)")
 		assert.Equal(t, *res.Installed.BuildTime, *res.Latest.BuildTime, "build times should be the same")
-		assert.Equal(t, "pmm2-server", res.Latest.Repo)
+		assert.Equal(t, "local", res.Latest.Repo)
 
 		// cached result
 		res2, resT2 := checker.checkResult(ctx)

--- a/services/supervisord/devcontainer_test.go
+++ b/services/supervisord/devcontainer_test.go
@@ -52,7 +52,7 @@ func TestDevContainer(t *testing.T) {
 		assert.True(t, strings.HasPrefix(fullVersion, "2."), "%s", fullVersion)
 		require.NotEmpty(t, info.BuildTime)
 		assert.True(t, info.BuildTime.After(gaReleaseDate), "BuildTime = %s", info.BuildTime)
-		assert.Equal(t, "local", info.Repo)
+		assert.Equal(t, "pmm2-server", info.Repo)
 
 		info2 := checker.Installed(ctx)
 		assert.Equal(t, info, info2)
@@ -70,7 +70,7 @@ func TestDevContainer(t *testing.T) {
 		assert.True(t, strings.HasPrefix(installedFullVersion, "2."), "%s", installedFullVersion)
 		require.NotEmpty(t, res.Installed.BuildTime)
 		assert.True(t, res.Installed.BuildTime.After(gaReleaseDate), "Installed.BuildTime = %s", res.Installed.BuildTime)
-		assert.Equal(t, "local", res.Installed.Repo)
+		assert.Equal(t, "pmm2-server", res.Installed.Repo)
 
 		assert.True(t, strings.HasPrefix(res.Latest.Version, "2."), "%s", res.Latest.Version)
 		latestFullVersion, isFeatureBranch := normalizeFullversion(&res.Latest)
@@ -90,7 +90,7 @@ func TestDevContainer(t *testing.T) {
 		assert.Empty(t, res.LatestNewsURL, "latest_news_url should be empty")
 		assert.Equal(t, res.Installed, res.Latest, "version should be the same (latest)")
 		assert.Equal(t, *res.Installed.BuildTime, *res.Latest.BuildTime, "build times should be the same")
-		assert.Equal(t, "local", res.Latest.Repo)
+		assert.Equal(t, "pmm2-server", res.Latest.Repo)
 
 		// cached result
 		res2, resT2 := checker.checkResult(ctx)


### PR DESCRIPTION
[PMM-8116](https://jira.percona.com/browse/PMM-8116)

- [x] Build: https://github.com/Percona-Lab/pmm-submodules/pull/1833

- [x] Links to other linked pull requests (optional).
https://github.com/percona/pmm/pull/743
https://github.com/percona/pmm-agent/pull/271
https://github.com/percona/qan-api2/pull/111
---
- [x] Tests passed.
- [ ] Feature build pass.
- [x] (Re)requested review.
- [x] Fix conflicts with target branch.
- [ ] Update API dependency.
- [x] Update jira ticket description if needed.
- [x] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.