### PR TITLE
Increase github jobs timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   test:
     name: Test
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Jobs started to fail constantly because of jobs execution timeout, so the quick fix is to increase the timeout to 30m.