### PR TITLE
PMM 9156: Use agent version for base path logic

### DIFF
--- a/services/agents/agents.go
+++ b/services/agents/agents.go
@@ -54,9 +54,8 @@ func redactWords(agent *models.Agent) []string {
 }
 
 // pathsBase returns paths base and in case of unsupported PMM client old hardcoded value.
-func pathsBase(ver, tdpLeft, tdpRight string) string {
-	pmmAgentVersion, err := version.Parse(ver)
-	if err != nil || pmmAgentVersion.Less(pmmAgentPathsBaseSupport) {
+func pathsBase(agentVersion *version.Parsed, tdpLeft, tdpRight string) string {
+	if agentVersion == nil || agentVersion.Less(pmmAgentPathsBaseSupport) {
 		return "/usr/local/percona/pmm2"
 	}
 

--- a/services/agents/agents_test.go
+++ b/services/agents/agents_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/percona/pmm/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,9 +41,9 @@ func requireNoDuplicateFlags(t *testing.T, flags []string) {
 func TestPathsBaseForDifferentVersions(t *testing.T) {
 	left := "{{"
 	right := "}}"
-	assert.Equal(t, "/usr/local/percona/pmm2", pathsBase("2.22.01", left, right))
-	assert.Equal(t, "{{ .paths_base }}", pathsBase("2.23.0", left, right))
-	assert.Equal(t, "{{ .paths_base }}", pathsBase("2.23.0-3-g7aa417c", left, right))
-	assert.Equal(t, "{{ .paths_base }}", pathsBase("2.23.0-beta4", left, right))
-	assert.Equal(t, "{{ .paths_base }}", pathsBase("2.23.0-rc1", left, right))
+	assert.Equal(t, "/usr/local/percona/pmm2", pathsBase(version.MustParse("2.22.01"), left, right))
+	assert.Equal(t, "{{ .paths_base }}", pathsBase(version.MustParse("2.23.0"), left, right))
+	assert.Equal(t, "{{ .paths_base }}", pathsBase(version.MustParse("2.23.0-3-g7aa417c"), left, right))
+	assert.Equal(t, "{{ .paths_base }}", pathsBase(version.MustParse("2.23.0-beta4"), left, right))
+	assert.Equal(t, "{{ .paths_base }}", pathsBase(version.MustParse("2.23.0-rc1"), left, right))
 }

--- a/services/agents/mysql.go
+++ b/services/agents/mysql.go
@@ -24,13 +24,14 @@ import (
 	"github.com/AlekSi/pointer"
 	"github.com/percona/pmm/api/agentpb"
 	"github.com/percona/pmm/api/inventorypb"
+	"github.com/percona/pmm/version"
 
 	"github.com/percona/pmm-managed/models"
 	"github.com/percona/pmm-managed/utils/collectors"
 )
 
 // mysqldExporterConfig returns desired configuration of mysqld_exporter process.
-func mysqldExporterConfig(service *models.Service, exporter *models.Agent, redactMode redactMode) *agentpb.SetStateRequest_AgentProcess {
+func mysqldExporterConfig(service *models.Service, exporter *models.Agent, redactMode redactMode, agentVersion *version.Parsed) *agentpb.SetStateRequest_AgentProcess {
 	tdp := exporter.TemplateDelimiters(service)
 
 	args := []string{
@@ -62,9 +63,9 @@ func mysqldExporterConfig(service *models.Service, exporter *models.Agent, redac
 		"--collect.standard.go",
 		"--collect.standard.process",
 
-		"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/custom-queries/mysql/low-resolution",
-		"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/custom-queries/mysql/medium-resolution",
-		"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/custom-queries/mysql/high-resolution",
+		"--collect.custom_query.lr.directory=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/custom-queries/mysql/low-resolution",
+		"--collect.custom_query.mr.directory=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/custom-queries/mysql/medium-resolution",
+		"--collect.custom_query.hr.directory=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/custom-queries/mysql/high-resolution",
 
 		"--exporter.max-idle-conns=3",
 		"--exporter.max-open-conns=3",

--- a/services/agents/mysql_test.go
+++ b/services/agents/mysql_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/AlekSi/pointer"
 	"github.com/percona/pmm/api/agentpb"
 	"github.com/percona/pmm/api/inventorypb"
+	"github.com/percona/pmm/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,7 +41,10 @@ func TestMySQLdExporterConfig(t *testing.T) {
 		Password:      pointer.ToString("s3cur3 p@$$w0r4."),
 		AgentPassword: pointer.ToString("agent-password"),
 	}
-	actual := mysqldExporterConfig(mysql, exporter, redactSecrets)
+	// TODO: Populate version information
+	agentVersion := &version.Parsed{}
+
+	actual := mysqldExporterConfig(mysql, exporter, redactSecrets, agentVersion)
 	expected := &agentpb.SetStateRequest_AgentProcess{
 		Type:               inventorypb.AgentType_MYSQLD_EXPORTER,
 		TemplateLeftDelim:  "{{",
@@ -49,11 +53,11 @@ func TestMySQLdExporterConfig(t *testing.T) {
 			"--collect.auto_increment.columns",
 			"--collect.binlog_size",
 			"--collect.custom_query.hr",
-			"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/high-resolution",
+			"--collect.custom_query.hr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/high-resolution",
 			"--collect.custom_query.lr",
-			"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/low-resolution",
+			"--collect.custom_query.lr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/low-resolution",
 			"--collect.custom_query.mr",
-			"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/medium-resolution",
+			"--collect.custom_query.mr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/medium-resolution",
 			"--collect.engine_innodb_status",
 			"--collect.engine_tokudb_status",
 			"--collect.global_status",
@@ -98,13 +102,13 @@ func TestMySQLdExporterConfig(t *testing.T) {
 
 	t.Run("EmptyPassword", func(t *testing.T) {
 		exporter.Password = nil
-		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets)
+		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets, agentVersion)
 		assert.Equal(t, "DATA_SOURCE_NAME=username@tcp(1.2.3.4:3306)/?timeout=1s", actual.Env[0])
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
 		exporter.Username = nil
-		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets)
+		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets, agentVersion)
 		assert.Equal(t, "DATA_SOURCE_NAME=tcp(1.2.3.4:3306)/?timeout=1s", actual.Env[0])
 	})
 
@@ -115,7 +119,7 @@ func TestMySQLdExporterConfig(t *testing.T) {
 			TLSCert: "content-of-tls-certificate-key",
 			TLSKey:  "content-of-tls-key",
 		}
-		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets)
+		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets, agentVersion)
 		expected := "DATA_SOURCE_NAME=tcp(1.2.3.4:3306)/?timeout=1s&tls=custom"
 		assert.Equal(t, expected, actual.Env[0])
 		expectedFiles := map[string]string{
@@ -145,7 +149,10 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 			TLSKey:  "content-of-tls-key",
 		},
 	}
-	actual := mysqldExporterConfig(mysql, exporter, redactSecrets)
+	// TODO: Populate version information
+	agentVersion := &version.Parsed{}
+
+	actual := mysqldExporterConfig(mysql, exporter, redactSecrets, agentVersion)
 	expected := &agentpb.SetStateRequest_AgentProcess{
 		Type:               inventorypb.AgentType_MYSQLD_EXPORTER,
 		TemplateLeftDelim:  "{{",
@@ -153,11 +160,11 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 		Args: []string{
 			"--collect.binlog_size",
 			"--collect.custom_query.hr",
-			"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/high-resolution",
+			"--collect.custom_query.hr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/high-resolution",
 			"--collect.custom_query.lr",
-			"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/low-resolution",
+			"--collect.custom_query.lr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/low-resolution",
 			"--collect.custom_query.mr",
-			"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/medium-resolution",
+			"--collect.custom_query.mr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/medium-resolution",
 			"--collect.engine_innodb_status",
 			"--collect.engine_tokudb_status",
 			"--collect.global_status",
@@ -203,13 +210,13 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 
 	t.Run("EmptyPassword", func(t *testing.T) {
 		exporter.Password = nil
-		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets)
+		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets, agentVersion)
 		assert.Equal(t, "DATA_SOURCE_NAME=username@tcp(1.2.3.4:3306)/?timeout=1s&tls=custom", actual.Env[0])
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
 		exporter.Username = nil
-		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets)
+		actual := mysqldExporterConfig(mysql, exporter, exposeSecrets, agentVersion)
 		assert.Equal(t, "DATA_SOURCE_NAME=tcp(1.2.3.4:3306)/?timeout=1s&tls=custom", actual.Env[0])
 	})
 }
@@ -226,7 +233,10 @@ func TestMySQLdExporterConfigDisabledCollectors(t *testing.T) {
 		Password:           pointer.ToString("s3cur3 p@$$w0r4."),
 		DisabledCollectors: []string{"heartbeat", "info_schema.clientstats", "perf_schema.eventsstatements", "custom_query.hr"},
 	}
-	actual := mysqldExporterConfig(mysql, exporter, redactSecrets)
+	// TODO: Populate version information
+	agentVersion := &version.Parsed{}
+
+	actual := mysqldExporterConfig(mysql, exporter, redactSecrets, agentVersion)
 	expected := &agentpb.SetStateRequest_AgentProcess{
 		Type:               inventorypb.AgentType_MYSQLD_EXPORTER,
 		TemplateLeftDelim:  "{{",
@@ -234,11 +244,11 @@ func TestMySQLdExporterConfigDisabledCollectors(t *testing.T) {
 		Args: []string{
 			"--collect.auto_increment.columns",
 			"--collect.binlog_size",
-			"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/high-resolution",
+			"--collect.custom_query.hr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/high-resolution",
 			"--collect.custom_query.lr",
-			"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/low-resolution",
+			"--collect.custom_query.lr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/low-resolution",
 			"--collect.custom_query.mr",
-			"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/custom-queries/mysql/medium-resolution",
+			"--collect.custom_query.mr.directory=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/custom-queries/mysql/medium-resolution",
 			"--collect.engine_innodb_status",
 			"--collect.engine_tokudb_status",
 			"--collect.global_status",

--- a/services/agents/node.go
+++ b/services/agents/node.go
@@ -23,20 +23,21 @@ import (
 	"github.com/AlekSi/pointer"
 	"github.com/percona/pmm/api/agentpb"
 	"github.com/percona/pmm/api/inventorypb"
+	"github.com/percona/pmm/version"
 
 	"github.com/percona/pmm-managed/models"
 	"github.com/percona/pmm-managed/utils/collectors"
 )
 
-func nodeExporterConfig(node *models.Node, exporter *models.Agent) *agentpb.SetStateRequest_AgentProcess {
+func nodeExporterConfig(node *models.Node, exporter *models.Agent, agentVersion *version.Parsed) *agentpb.SetStateRequest_AgentProcess {
 	tdp := models.TemplateDelimsPair(
 		pointer.GetString(exporter.MetricsPath),
 	)
 
 	args := []string{
-		"--collector.textfile.directory.lr=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/textfile-collector/low-resolution",
-		"--collector.textfile.directory.mr=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/textfile-collector/medium-resolution",
-		"--collector.textfile.directory.hr=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/textfile-collector/high-resolution",
+		"--collector.textfile.directory.lr=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/textfile-collector/low-resolution",
+		"--collector.textfile.directory.mr=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/textfile-collector/medium-resolution",
+		"--collector.textfile.directory.hr=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/textfile-collector/high-resolution",
 
 		"--web.disable-exporter-metrics", // we enable them as a part of HR metrics
 

--- a/services/agents/node_test.go
+++ b/services/agents/node_test.go
@@ -19,9 +19,9 @@ package agents
 import (
 	"testing"
 
-	"github.com/AlekSi/pointer"
 	"github.com/percona/pmm/api/agentpb"
 	"github.com/percona/pmm/api/inventorypb"
+	"github.com/percona/pmm/version"
 	"github.com/stretchr/testify/require"
 
 	"github.com/percona/pmm-managed/models"
@@ -33,7 +33,9 @@ func TestNodeExporterConfig(t *testing.T) {
 		exporter := &models.Agent{
 			AgentID: "agent-id",
 		}
-		actual := nodeExporterConfig(node, exporter)
+		agentVersion := version.MustParse("2.15.1")
+
+		actual := nodeExporterConfig(node, exporter, agentVersion)
 		expected := &agentpb.SetStateRequest_AgentProcess{
 			Type:               inventorypb.AgentType_NODE_EXPORTER,
 			TemplateLeftDelim:  "{{",
@@ -62,9 +64,9 @@ func TestNodeExporterConfig(t *testing.T) {
 				"--collector.standard.go",
 				"--collector.standard.process",
 				"--collector.stat",
-				"--collector.textfile.directory.hr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/high-resolution",
-				"--collector.textfile.directory.lr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/low-resolution",
-				"--collector.textfile.directory.mr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/medium-resolution",
+				"--collector.textfile.directory.hr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/high-resolution",
+				"--collector.textfile.directory.lr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/low-resolution",
+				"--collector.textfile.directory.mr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/medium-resolution",
 				"--collector.textfile.hr",
 				"--collector.textfile.lr",
 				"--collector.textfile.mr",
@@ -120,7 +122,9 @@ func TestNodeExporterConfig(t *testing.T) {
 			AgentID:            "agent-id",
 			DisabledCollectors: []string{"cpu", "netstat", "netstat.fields", "vmstat", "meminfo"},
 		}
-		actual := nodeExporterConfig(node, exporter)
+		agentVersion := version.MustParse("2.15.1")
+
+		actual := nodeExporterConfig(node, exporter, agentVersion)
 		expected := &agentpb.SetStateRequest_AgentProcess{
 			Type:               inventorypb.AgentType_NODE_EXPORTER,
 			TemplateLeftDelim:  "{{",
@@ -140,9 +144,9 @@ func TestNodeExporterConfig(t *testing.T) {
 				"--collector.standard.go",
 				"--collector.standard.process",
 				"--collector.stat",
-				"--collector.textfile.directory.hr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/high-resolution",
-				"--collector.textfile.directory.lr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/low-resolution",
-				"--collector.textfile.directory.mr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/medium-resolution",
+				"--collector.textfile.directory.hr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/high-resolution",
+				"--collector.textfile.directory.lr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/low-resolution",
+				"--collector.textfile.directory.mr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/medium-resolution",
 				"--collector.textfile.hr",
 				"--collector.textfile.lr",
 				"--collector.textfile.mr",
@@ -198,15 +202,17 @@ func TestNodeExporterConfig(t *testing.T) {
 		exporter := &models.Agent{
 			AgentID: "agent-id",
 		}
-		actual := nodeExporterConfig(node, exporter)
+		agentVersion := version.MustParse("2.15.1")
+
+		actual := nodeExporterConfig(node, exporter, agentVersion)
 		expected := &agentpb.SetStateRequest_AgentProcess{
 			Type:               inventorypb.AgentType_NODE_EXPORTER,
 			TemplateLeftDelim:  "{{",
 			TemplateRightDelim: "}}",
 			Args: []string{
-				"--collector.textfile.directory.hr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/high-resolution",
-				"--collector.textfile.directory.lr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/low-resolution",
-				"--collector.textfile.directory.mr=" + pathsBase(pointer.GetString(exporter.Version), "{{", "}}") + "/collectors/textfile-collector/medium-resolution",
+				"--collector.textfile.directory.hr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/high-resolution",
+				"--collector.textfile.directory.lr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/low-resolution",
+				"--collector.textfile.directory.mr=" + pathsBase(agentVersion, "{{", "}}") + "/collectors/textfile-collector/medium-resolution",
 				"--web.disable-exporter-metrics",
 				"--web.listen-address=:{{ .listen_port }}",
 			},

--- a/services/agents/postgresql.go
+++ b/services/agents/postgresql.go
@@ -34,7 +34,7 @@ var postgresExporterAutodiscoveryVersion = version.MustParse("2.15.99")
 
 // postgresExporterConfig returns desired configuration of postgres_exporter process.
 func postgresExporterConfig(service *models.Service, exporter *models.Agent, redactMode redactMode,
-	pmmAgentVersion *version.Parsed) *agentpb.SetStateRequest_AgentProcess {
+	agentVersion *version.Parsed) *agentpb.SetStateRequest_AgentProcess {
 
 	if service.DatabaseName == "" {
 		panic("database name not set")
@@ -52,13 +52,13 @@ func postgresExporterConfig(service *models.Service, exporter *models.Agent, red
 		// HR
 		"--collect.custom_query.hr",
 
-		"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/custom-queries/postgresql/low-resolution",
-		"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/custom-queries/postgresql/medium-resolution",
-		"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(exporter.Version), tdp.Left, tdp.Right) + "/collectors/custom-queries/postgresql/high-resolution",
+		"--collect.custom_query.lr.directory=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/custom-queries/postgresql/low-resolution",
+		"--collect.custom_query.mr.directory=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/custom-queries/postgresql/medium-resolution",
+		"--collect.custom_query.hr.directory=" + pathsBase(agentVersion, tdp.Left, tdp.Right) + "/collectors/custom-queries/postgresql/high-resolution",
 		"--web.listen-address=:" + tdp.Left + " .listen_port " + tdp.Right,
 	}
 
-	if !pmmAgentVersion.Less(postgresExporterAutodiscoveryVersion) {
+	if !agentVersion.Less(postgresExporterAutodiscoveryVersion) {
 		args = append(args,
 			"--auto-discover-databases",
 			"--exclude-databases=template0,template1,postgres,cloudsqladmin,pmm-managed-dev,azure_maintenance",

--- a/services/agents/postgresql_test.go
+++ b/services/agents/postgresql_test.go
@@ -57,11 +57,11 @@ func (s *PostgresExporterConfigTestSuite) SetupTest() {
 		TemplateRightDelim: "}}",
 		Args: []string{
 			"--collect.custom_query.hr",
-			"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/high-resolution",
+			"--collect.custom_query.hr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/high-resolution",
 			"--collect.custom_query.lr",
-			"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
+			"--collect.custom_query.lr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
 			"--collect.custom_query.mr",
-			"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
+			"--collect.custom_query.mr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
 			"--web.listen-address=:{{ .listen_port }}",
 		},
 		Env: []string{
@@ -139,6 +139,7 @@ func (s *PostgresExporterConfigTestSuite) TestSocket() {
 }
 
 func (s *PostgresExporterConfigTestSuite) TestDisabledCollectors() {
+	s.pmmAgentVersion = &version.Parsed{}
 	s.postgresql.Address = nil
 	s.postgresql.Port = nil
 	s.postgresql.Socket = pointer.ToString("/var/run/postgres")
@@ -152,9 +153,9 @@ func (s *PostgresExporterConfigTestSuite) TestDisabledCollectors() {
 		TemplateRightDelim: "}}",
 		Args: []string{
 			"--collect.custom_query.lr",
-			"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
+			"--collect.custom_query.lr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
 			"--collect.custom_query.mr",
-			"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
+			"--collect.custom_query.mr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
 			"--web.listen-address=:{{ .listen_port }}",
 		},
 	}
@@ -186,11 +187,11 @@ func (s *PostgresExporterConfigTestSuite) TestAutoDiscovery() {
 		Args: []string{
 			"--auto-discover-databases",
 			"--collect.custom_query.hr",
-			"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/high-resolution",
+			"--collect.custom_query.hr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/high-resolution",
 			"--collect.custom_query.lr",
-			"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
+			"--collect.custom_query.lr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
 			"--collect.custom_query.mr",
-			"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
+			"--collect.custom_query.mr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
 			"--exclude-databases=template0,template1,postgres,cloudsqladmin,pmm-managed-dev,azure_maintenance",
 			"--web.listen-address=:{{ .listen_port }}",
 		},
@@ -237,11 +238,11 @@ func (s *PostgresExporterConfigTestSuite) TestAzureTimeout() {
 		Args: []string{
 			"--auto-discover-databases",
 			"--collect.custom_query.hr",
-			"--collect.custom_query.hr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/high-resolution",
+			"--collect.custom_query.hr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/high-resolution",
 			"--collect.custom_query.lr",
-			"--collect.custom_query.lr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
+			"--collect.custom_query.lr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/low-resolution",
 			"--collect.custom_query.mr",
-			"--collect.custom_query.mr.directory=" + pathsBase(pointer.GetString(s.exporter.Version), "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
+			"--collect.custom_query.mr.directory=" + pathsBase(s.pmmAgentVersion, "{{", "}}") + "/collectors/custom-queries/postgresql/medium-resolution",
 			"--exclude-databases=template0,template1,postgres,cloudsqladmin,pmm-managed-dev,azure_maintenance",
 			"--web.listen-address=:{{ .listen_port }}",
 		},

--- a/services/agents/state.go
+++ b/services/agents/state.go
@@ -189,7 +189,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			if err != nil {
 				return err
 			}
-			agentProcesses[row.AgentID] = nodeExporterConfig(node, row)
+			agentProcesses[row.AgentID] = nodeExporterConfig(node, row, pmmAgentVersion)
 
 		case models.RDSExporterType:
 			node, err := models.FindNodeByID(u.db.Querier, pointer.GetString(row.NodeID))
@@ -223,7 +223,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 
 			switch row.AgentType {
 			case models.MySQLdExporterType:
-				agentProcesses[row.AgentID] = mysqldExporterConfig(service, row, redactMode)
+				agentProcesses[row.AgentID] = mysqldExporterConfig(service, row, redactMode, pmmAgentVersion)
 			case models.MongoDBExporterType:
 				agentProcesses[row.AgentID] = mongodbExporterConfig(service, row, redactMode, pmmAgentVersion)
 			case models.PostgresExporterType:


### PR DESCRIPTION
In PMM 2.23.0, we introduced support for non-standard base path. For computing paths derived from base path, we need to use agent version. However, we were using exporter version instead of agent version till now. This patch fixes the logic.

[PMM-9156](https://jira.percona.com/browse/PMM-9156)

- [ ] Build: https://github.com/Percona-Lab/pmm-submodules/pull/0

- [ ] Links to other linked pull requests (optional).
---
- [ ] Tests passed.
- [ ] Feature build pass.
- [ ] (Re)requested review.
- [ ] Fix conflicts with target branch.
- [ ] Update API dependency.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.