### PR TITLE
PMM-9050 parseSAASHost: avoid including the port if it's passed

### DIFF
--- a/utils/envvars/parser_test.go
+++ b/utils/envvars/parser_test.go
@@ -165,9 +165,10 @@ func TestEnvVarValidator(t *testing.T) {
 			respVal string
 		}{
 			{value: "host", err: "", respVal: "host"},
-			{value: ":111", err: `saas host can't have port set: it's signed for domain without the port`, respVal: ""},
-			{value: "host:555", err: "saas host can't have port set: it's signed for domain without the port", respVal: ""},
-			{value: "ho:st:444", err: "saas host can't have port set: it's signed for domain without the port", respVal: ""},
+			{value: ":111", err: `environment variable "PERCONA_TEST_SAAS_HOST" has invalid format ":111". Expected host[:port]`, respVal: ""},
+			{value: "host:555", err: "", respVal: "host"},
+			{value: "[2001:cafe:8221:9a0f:4dc7:4bb:8581:d186]:333", err: "", respVal: "2001:cafe:8221:9a0f:4dc7:4bb:8581:d186"},
+			{value: "ho:st:444", err: "address ho:st:444: too many colons in address", respVal: ""},
 		}
 		for _, c := range userCase {
 			value, err := parseSAASHost(c.value)


### PR DESCRIPTION
[PMM-9050](https://jira.percona.com/browse/PMM-9050)

This is a fix for a bug that makes pmm-managed crash when port is part of the SAAS host. We now can handle such state. Parsing out the host only.

- [ ] Build: https://github.com/Percona-Lab/pmm-submodules/pull/2178

- [ ] Links to other linked pull requests (optional).
---
- [ ] Tests passed.
- [ ] Feature build pass.
- [ ] (Re)requested review.
- [ ] Fix conflicts with target branch.
- [ ] Update API dependency.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.