### PR TITLE
PMM-9304 Disable dbstats & topmetrics

### DIFF
--- a/services/agents/mongodb.go
+++ b/services/agents/mongodb.go
@@ -115,12 +115,14 @@ func v225Args(exporter *models.Agent, disabledCollectors []string, tdp *models.D
 			enabled:      true,
 			disableParam: "--no-collector.replicasetstatus",
 		},
+		// disabled until we have better information on the resources usage impact
 		"dbstats": {
-			enabled:     true,
+			enabled:     false,
 			enableParam: "--collector.dbstats",
 		},
+		// disabled until we have better information on the resources usage impact
 		"topmetrics": {
-			enabled:     true,
+			enabled:     false,
 			enableParam: "--collector.topmetrics",
 		},
 	}

--- a/services/agents/mongodb_test.go
+++ b/services/agents/mongodb_test.go
@@ -49,8 +49,10 @@ func TestMongodbExporterConfig225(t *testing.T) {
 		TemplateLeftDelim:  "{{",
 		TemplateRightDelim: "}}",
 		Args: []string{
-			"--collector.dbstats",
-			"--collector.topmetrics",
+			// temporarily disabled by PMM-9304 until we have more information about the resources
+			// consumption for these 2 collectors.
+			// "--collector.dbstats",
+			// "--collector.topmetrics",
 			"--compatible-mode",
 			"--discovering-mode",
 			"--mongodb.global-conn-pool",
@@ -74,8 +76,10 @@ func TestMongodbExporterConfig225(t *testing.T) {
 		}
 		expected.Args = []string{
 			"--collector.collstats-limit=79014",
-			"--collector.dbstats",
-			"--collector.topmetrics",
+			// temporarily disabled by PMM-9304 until we have more information about the resources
+			// consumption for these 2 collectors.
+			// "--collector.dbstats",
+			// "--collector.topmetrics",
 			"--compatible-mode",
 			"--discovering-mode",
 			"--mongodb.collstats-colls=col1,col2,col3",

--- a/testdata/supervisord.d/grafana.ini
+++ b/testdata/supervisord.d/grafana.ini
@@ -12,7 +12,6 @@ command =
         cfg:default.log.mode=console
         cfg:default.log.console.format=console
         cfg:default.server.root_url="https://%%(domain)s/graph"
-
 user = grafana
 directory = /usr/share/grafana
 autorestart = true

--- a/utils/envvars/parser_test.go
+++ b/utils/envvars/parser_test.go
@@ -181,6 +181,25 @@ func TestEnvVarValidator(t *testing.T) {
 		}
 	})
 
+	t.Run("Parse Platform API Timeout", func(t *testing.T) {
+		t.Parallel()
+
+		userCase := []struct {
+			value   string
+			respVal time.Duration
+			msg     string
+		}{
+			{value: "", respVal: time.Second * 30, msg: "Environment variable \"PERCONA_PLATFORM_API_TIMEOUT\" is not set, using \"30s\" as a default timeout for platform API."},
+			{value: "10s", respVal: time.Second * 10, msg: "Using \"10s\" as a timeout for platform API."},
+			{value: "xxx", respVal: time.Second * 30, msg: "Using \"30s\" as a default: failed to parse platform API timeout \"xxx\": invalid duration error."},
+		}
+		for _, c := range userCase {
+			value, msg := parsePlatformAPITimeout(c.value)
+			assert.Equal(t, c.respVal, value)
+			assert.Equal(t, c.msg, msg)
+		}
+	})
+
 	t.Run("Grafana env vars", func(t *testing.T) {
 		t.Parallel()
 

--- a/utils/saasreq/request.go
+++ b/utils/saasreq/request.go
@@ -27,9 +27,17 @@ import (
 	"time"
 
 	"github.com/percona/pmm/utils/tlsconfig"
+
+	"github.com/percona/pmm-managed/utils/envvars"
+	"github.com/percona/pmm-managed/utils/logger"
 )
 
-const dialTimeout = 10 * time.Second
+var dialTimeout time.Duration
+
+func init() {
+	l := logger.Get(logger.Set(context.Background(), "saasreq init"))
+	dialTimeout = envvars.GetPlatformAPITimeout(l)
+}
 
 // MakeRequest creates http/https POST request to Percona Platform
 func MakeRequest(ctx context.Context, method string, endpoint, accessToken string, body io.Reader) ([]byte, error) {


### PR DESCRIPTION
[PMM-9304](https://jira.percona.com/browse/PMM-9304) Disable dbstat and topmetrics for mongodb exporter in default mode for 2.25.0

- [ ] Build: https://github.com/Percona-Lab/pmm-submodules/pull/2194

- [x] Tests passed.
- [ ] Feature build pass.