### PR TITLE
Pmm 9304 disable dtbstats and top

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # no `-mod=readonly` to test PRs made by @dependabot;
       # `git diff --exit-code` step below still checks what we need
       GOFLAGS: -v
-      PMM_SERVER_IMAGE: public.ecr.aws/e7j3v3n0/pmm-server:dev-latest
+      PMM_SERVER_IMAGE: perconalab/pmm-server:dev-latest
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
       OAUTH_PMM_CLIENT_ID: ${{ secrets.OAUTH_PMM_CLIENT_ID }}

--- a/api-tests/docker-compose.yml
+++ b/api-tests/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   pmm-server:
-    image: ${PMM_SERVER_IMAGE:-public.ecr.aws/e7j3v3n0/pmm-server:dev-latest}
+    image: ${PMM_SERVER_IMAGE:-perconalab/pmm-server:dev-latest}
     container_name: pmm-agent_pmm-server
     ports:
       - 127.0.0.1:80:80

--- a/api-tests/server/auth_test.go
+++ b/api-tests/server/auth_test.go
@@ -278,19 +278,7 @@ func TestPermissions(t *testing.T) {
 			{userType: "editor", login: editor, apiKey: editorAPIKey, statusCode: 401},
 			{userType: "admin", login: admin, apiKey: adminAPIKey, statusCode: 200},
 		}},
-		{name: "platform-sign-up", url: "/v1/Platform/SignUp", method: "POST", userCase: []userCase{
-			{userType: "default", login: none, statusCode: 401},
-			{userType: "viewer", login: viewer, apiKey: viewerAPIKey, statusCode: 401},
-			{userType: "editor", login: editor, apiKey: editorAPIKey, statusCode: 401},
-			{userType: "admin", login: admin, apiKey: adminAPIKey, statusCode: 400}, // We send bad request, but have access to endpoint
-		}},
 		{name: "platform-connect", url: "/v1/Platform/Connect", method: "POST", userCase: []userCase{
-			{userType: "default", login: none, statusCode: 401},
-			{userType: "viewer", login: viewer, apiKey: viewerAPIKey, statusCode: 401},
-			{userType: "editor", login: editor, apiKey: editorAPIKey, statusCode: 401},
-			{userType: "admin", login: admin, apiKey: adminAPIKey, statusCode: 400}, // We send bad request, but have access to endpoint
-		}},
-		{name: "platform-sign-out", url: "/v1/Platform/SignOut", method: "POST", userCase: []userCase{
 			{userType: "default", login: none, statusCode: 401},
 			{userType: "viewer", login: viewer, apiKey: viewerAPIKey, statusCode: 401},
 			{userType: "editor", login: editor, apiKey: editorAPIKey, statusCode: 401},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   pmm-managed-server:
-    image: ${PMM_SERVER_IMAGE:-public.ecr.aws/e7j3v3n0/pmm-server:dev-latest}
+    image: ${PMM_SERVER_IMAGE:-perconalab/pmm-server:dev-latest}
     container_name: pmm-managed-server
     hostname: pmm-managed-server
     environment:

--- a/services/agents/mongodb.go
+++ b/services/agents/mongodb.go
@@ -115,12 +115,14 @@ func v225Args(exporter *models.Agent, disabledCollectors []string, tdp *models.D
 			enabled:      true,
 			disableParam: "--no-collector.replicasetstatus",
 		},
+		// disabled until we have better information on the resources usage impact
 		"dbstats": {
-			enabled:     true,
+			enabled:     false,
 			enableParam: "--collector.dbstats",
 		},
+		// disabled until we have better information on the resources usage impact
 		"topmetrics": {
-			enabled:     true,
+			enabled:     false,
 			enableParam: "--collector.topmetrics",
 		},
 	}

--- a/services/agents/mongodb_test.go
+++ b/services/agents/mongodb_test.go
@@ -49,8 +49,10 @@ func TestMongodbExporterConfig225(t *testing.T) {
 		TemplateLeftDelim:  "{{",
 		TemplateRightDelim: "}}",
 		Args: []string{
-			"--collector.dbstats",
-			"--collector.topmetrics",
+			// temporarily disabled by PMM-9304 until we have more information about the resources
+			// consumption for these 2 collectors.
+			// "--collector.dbstats",
+			// "--collector.topmetrics",
 			"--compatible-mode",
 			"--discovering-mode",
 			"--mongodb.global-conn-pool",
@@ -74,8 +76,10 @@ func TestMongodbExporterConfig225(t *testing.T) {
 		}
 		expected.Args = []string{
 			"--collector.collstats-limit=79014",
-			"--collector.dbstats",
-			"--collector.topmetrics",
+			// temporarily disabled by PMM-9304 until we have more information about the resources
+			// consumption for these 2 collectors.
+			// "--collector.dbstats",
+			// "--collector.topmetrics",
 			"--compatible-mode",
 			"--discovering-mode",
 			"--mongodb.collstats-colls=col1,col2,col3",

--- a/services/supervisord/devcontainer_test.go
+++ b/services/supervisord/devcontainer_test.go
@@ -82,7 +82,7 @@ func TestDevContainer(t *testing.T) {
 		assert.True(t, res.Latest.BuildTime.After(gaReleaseDate), "Latest.BuildTime = %s", res.Latest.BuildTime)
 		assert.NotEmpty(t, res.Latest.Repo)
 
-		// We assume that the latest public.ecr.aws/e7j3v3n0/pmm-server:dev-latest image
+		// We assume that the latest perconalab/pmm-server:dev-latest image
 		// always contains the latest pmm-update package versions.
 		// If this test fails, re-pull them and recreate devcontainer.
 		t.Log("Assuming the latest pmm-update version.")


### PR DESCRIPTION
[PMM-9304](https://jira.percona.com/browse/PMM-9304) Disable dbstat and topmetrics for mongodb exporter in default mode for 2.25.0

Already approved in https://github.com/percona/pmm-managed/pull/951
This is just a cherry pick to include it in 2.25
