### PR TITLE
Keep STT target lables in priority

### DIFF
--- a/services/checks/registry.go
+++ b/services/checks/registry.go
@@ -129,10 +129,10 @@ func (r *registry) getCheckResults() []services.STTCheckResult {
 func (r *registry) createAlert(name string, target *services.Target, result *check.Result, alertTTL time.Duration) *ammodels.PostableAlert {
 	labels := make(map[string]string, len(target.Labels)+len(result.Labels)+4)
 	annotations := make(map[string]string, 2)
-	for k, v := range target.Labels {
+	for k, v := range result.Labels {
 		labels[k] = v
 	}
-	for k, v := range result.Labels {
+	for k, v := range target.Labels {
 		labels[k] = v
 	}
 


### PR DESCRIPTION
Make STT target label more prioritized against STT result labels. Otherwise, STT check can override service name, for example.
---
- [ ] Tests passed.
- [ ] Feature build pass.
- [ ] (Re)requested review.
- [ ] Fix conflicts with target branch.
- [ ] Update API dependency.
- [ ] Update jira ticket description if needed.
- [ ] Attach screenshots/console output to confirm new behavior to jira ticket, if applicable.