### PR TITLE
PMM-9400 Added indexstats list

### DIFF
--- a/services/agents/mongodb.go
+++ b/services/agents/mongodb.go
@@ -138,6 +138,7 @@ func v226Args(exporter *models.Agent, tdp *models.DelimiterPair) []string {
 
 	if exporter.MongoDBOptions != nil && len(exporter.MongoDBOptions.StatsCollections) > 0 {
 		args = append(args, "--mongodb.collstats-colls="+strings.Join(exporter.MongoDBOptions.StatsCollections, ","))
+		args = append(args, "--mongodb.indexstats-colls="+strings.Join(exporter.MongoDBOptions.StatsCollections, ","))
 	}
 
 	if exporter.MongoDBOptions != nil {

--- a/services/agents/mongodb_test.go
+++ b/services/agents/mongodb_test.go
@@ -134,6 +134,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 			"--discovering-mode",
 			"--mongodb.collstats-colls=col1,col2,col3",
 			"--mongodb.global-conn-pool",
+			"--mongodb.indexstats-colls=col1,col2,col3",
 			"--web.listen-address=:{{ .listen_port }}",
 		}
 		actual := mongodbExporterConfig(mongodb, exporter, exposeSecrets, pmmAgentVersion)
@@ -159,6 +160,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 			"--discovering-mode",
 			"--mongodb.collstats-colls=col1,col2,col3",
 			"--mongodb.global-conn-pool",
+			"--mongodb.indexstats-colls=col1,col2,col3",
 			"--web.listen-address=:{{ .listen_port }}",
 		}
 		actual := mongodbExporterConfig(mongodb, exporter, exposeSecrets, pmmAgentVersion)
@@ -183,6 +185,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 			// since dbstats is not depending the number of collections present in the db.
 			"--mongodb.collstats-colls=db1.col1.one,db2.col2,db3",
 			"--mongodb.global-conn-pool",
+			"--mongodb.indexstats-colls=db1.col1.one,db2.col2,db3",
 			"--web.listen-address=:{{ .listen_port }}",
 		}
 		actual := mongodbExporterConfig(mongodb, exporter, exposeSecrets, pmmAgentVersion)
@@ -208,6 +211,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 			"--discovering-mode",
 			"--mongodb.collstats-colls=db1.col1.one,db2.col2,db3",
 			"--mongodb.global-conn-pool",
+			"--mongodb.indexstats-colls=db1.col1.one,db2.col2,db3",
 			"--web.listen-address=:{{ .listen_port }}",
 		}
 		actual := mongodbExporterConfig(mongodb, exporter, exposeSecrets, pmmAgentVersion)


### PR DESCRIPTION
[PMM-9400](https://jira.percona.com/browse/PMM-9400) Missing metrics for indexStats and collStats when all collectors enabled

In order to make it work correctly, we need to pass `--mongodb.indexstats-colls=` also, not only `--mongodb.collstats-colls=`

- [ ] Build: https://github.com/Percona-Lab/pmm-submodules/pull/2265

- [ ] Tests passed.
- [ ] Feature build pass.