### PR TITLE
PMM-9510 Remove tail from job

### DIFF
--- a/services/victoriametrics/scrape_configs.go
+++ b/services/victoriametrics/scrape_configs.go
@@ -146,8 +146,8 @@ func jobNameMapping(r rune) rune {
 	}
 }
 
-func jobName(agent *models.Agent, intervalName string, interval time.Duration) string {
-	return fmt.Sprintf("%s%s_%s-%s", agent.AgentType, strings.Map(jobNameMapping, agent.AgentID), intervalName, interval)
+func jobName(agent *models.Agent, intervalName string) string {
+	return fmt.Sprintf("%s%s_%s", agent.AgentType, strings.Map(jobNameMapping, agent.AgentID), intervalName)
 }
 
 func httpClientConfig(agent *models.Agent) config.HTTPClientConfig {

--- a/services/victoriametrics/scrape_configs.go
+++ b/services/victoriametrics/scrape_configs.go
@@ -146,7 +146,7 @@ func jobNameMapping(r rune) rune {
 	}
 }
 
-func jobName(agent *models.Agent, intervalName string) string {
+func jobName(agent *models.Agent, intervalName string, interval time.Duration) string {
 	return fmt.Sprintf("%s%s_%s", agent.AgentType, strings.Map(jobNameMapping, agent.AgentID), intervalName)
 }
 


### PR DESCRIPTION
[PMM-9510](https://jira.percona.com/browse/PMM-9510) [PMM-9399](https://jira.percona.com/browse/PMM-9399) [PMM-8070](https://jira.percona.com/browse/PMM-8070)

This changes fix issue with duplicate metrics after restart agent. Root reason of this is staleness metric [Link1](https://www.robustperception.io/staleness-and-promql) [Link2](https://docs.victoriametrics.com/vmagent.html#prometheus-staleness-markers) [Link3](https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness) [Link4](https://prometheus.io/docs/concepts/jobs_instances/)

- [submodules FB](https://github.com/Percona-Lab/pmm-submodules/pull/2331)
