### PR TITLE
Update timeout for 'Check' job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
   check:
     name: Check
-    timeout-minutes: 10
+    timeout-minutes: 15
     if: github.event_name == 'pull_request'
 
     strategy:


### PR DESCRIPTION
Linters job sometimes fails because it runs +/- 10 min