### PR TITLE
Fix CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Cache
         run: |
           docker exec pmm-managed-server go clean -testcache
+          docker exec --workdir=/root/go/src/github.com/percona/pmm-managed pmm-managed-server find . -type d -name fuzzdata -exec rm -r {} +
           rm -fr ~/.cache/go-build
           docker cp pmm-managed-server:/root/.cache/go-build ~/.cache/go-build
 
@@ -216,8 +217,8 @@ jobs:
       - name: Cache
         run: |
           docker exec pmm-managed-server go clean -testcache
+          docker exec --workdir=/root/go/src/github.com/percona/pmm-managed pmm-managed-server find . -type d -name fuzzdata -exec rm -r {} +
           rm -fr ~/.cache/go-build
-          mkdir -p ~/.cache
           docker cp pmm-managed-server:/root/.cache/go-build ~/.cache/go-build
 
       - name: Run debug commands on failure


### PR DESCRIPTION
Fuzzdata left after tests caused error during cache process. This PR fixes it.

Original issue: https://github.com/actions/cache/issues/753