### PR TITLE
PMM-9614 Add new migration for MongoDB options

### DIFF
--- a/models/database.go
+++ b/models/database.go
@@ -687,6 +687,10 @@ var databaseSchema = [][]string{
 		`ALTER TABLE percona_sso_details
 			ADD COLUMN organization_id VARCHAR`,
 	},
+	58: {
+		`UPDATE agents SET mongo_db_tls_options = jsonb_set(mongo_db_tls_options, '{stats_collections}', '[]')
+			WHERE 'mongo_db_tls_options' is not null`,
+	},
 }
 
 // ^^^ Avoid default values in schema definition. ^^^


### PR DESCRIPTION
MongoDB agent configuration is stored in Postgres database as a JSON blob. Usually, when we add new fields to the configuration, JSON blob can be used in a backward compatible manner. However, we ended up updating usage of stats_collections field from a string to string array. This requires a new migration, to allow newer version of server to work with data stored by older server versions.

PMM-9614

Build: SUBMODULES-0

- [ ] Links to other linked pull requests (optional).
