### PR TITLE
PMM-9863 remove yum-cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vscode/
+.DS_Store
 bin/
 fuzzdata/
 cover.out

--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -1,7 +1,5 @@
 # pmm-api-tests
 
-[![Build Status](https://travis-ci.com/Percona-Lab/pmm-api-tests.svg?branch=master)](https://travis-ci.com/Percona-Lab/pmm-api-tests)
-
 API tests for PMM 2.x
 
 # Setup Instructions

--- a/api-tests/server/logs_test.go
+++ b/api-tests/server/logs_test.go
@@ -54,7 +54,6 @@ func TestDownloadLogs(t *testing.T) {
 		"client/pmm-agent-config.yaml",
 		"client/pmm-agent-version.txt",
 		"client/status.json",
-		"cron.log",
 		"grafana.log",
 		"installed.json",
 		"nginx.conf",

--- a/services/supervisord/logs_test.go
+++ b/services/supervisord/logs_test.go
@@ -42,7 +42,6 @@ var commonExpectedFiles = []string{
 	"alertmanager.log",
 	"alertmanager.yml",
 	"clickhouse-server.log",
-	"cron.log",
 	"grafana.log",
 	"installed.json",
 	"nginx.conf",


### PR DESCRIPTION
PMM-9863

Build: [SUBMODULES-2459](https://github.com/Percona-Lab/pmm-submodules/pull/2459)

Note: `TestZip` and `TestFiles` will fail before we merge peer PRs in `pmm-server` and `pmm-update`. Otherwise both tests pass in the feature build https://pmm.cd.percona.com/job/pmm2-api-tests/9777/consoleFull.