### PR TITLE
PMM-9841 enable advisors by default

### DIFF
--- a/api-tests/server/alertmanager_test.go
+++ b/api-tests/server/alertmanager_test.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/percona/pmm/api/alertmanager/amclient"
 	"github.com/percona/pmm/api/alertmanager/amclient/alert"
-	serverClient "github.com/percona/pmm/api/serverpb/json/client"
-	"github.com/percona/pmm/api/serverpb/json/client/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -37,16 +35,6 @@ func TestAlertManager(t *testing.T) {
 		}
 
 		defer restoreSettingsDefaults(t)
-
-		// Enabling STT
-		res, err := serverClient.Default.Server.ChangeSettings(&server.ChangeSettingsParams{
-			Body: server.ChangeSettingsBody{
-				EnableStt: true,
-			},
-			Context: pmmapitests.Context,
-		})
-		require.NoError(t, err)
-		assert.True(t, res.Payload.Settings.SttEnabled)
 
 		// sync with pmm-managed
 		const (

--- a/api-tests/server/helpers.go
+++ b/api-tests/server/helpers.go
@@ -35,7 +35,7 @@ func restoreSettingsDefaults(t *testing.T) {
 
 	res, err := serverClient.Default.Server.ChangeSettings(&server.ChangeSettingsParams{
 		Body: server.ChangeSettingsBody{
-			DisableStt:      true,
+			EnableStt:       true,
 			EnableTelemetry: true,
 			MetricsResolutions: &server.ChangeSettingsParamsBodyMetricsResolutions{
 				Hr: "5s",
@@ -58,7 +58,7 @@ func restoreSettingsDefaults(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, true, res.Payload.Settings.TelemetryEnabled)
-	assert.Equal(t, false, res.Payload.Settings.SttEnabled)
+	assert.Equal(t, true, res.Payload.Settings.SttEnabled)
 	expectedResolutions := &server.ChangeSettingsOKBodySettingsMetricsResolutions{
 		Hr: "5s",
 		Mr: "10s",

--- a/api-tests/server/settings_test.go
+++ b/api-tests/server/settings_test.go
@@ -433,7 +433,7 @@ func TestSettings(t *testing.T) {
 					assert.True(t, resg.Payload.Settings.SttEnabled)
 				})
 
-				t.Run("DisableSTTifTelemetryIsDisabled", func(t *testing.T) {
+				t.Run("DisableTelemetryWhileSTTEnabled", func(t *testing.T) {
 					res, err := serverClient.Default.Server.ChangeSettings(&server.ChangeSettingsParams{
 						Body: server.ChangeSettingsBody{
 							DisableTelemetry: true,
@@ -441,7 +441,7 @@ func TestSettings(t *testing.T) {
 						Context: pmmapitests.Context,
 					})
 					require.NoError(t, err)
-					assert.False(t, res.Payload.Settings.SttEnabled)
+					assert.True(t, res.Payload.Settings.SttEnabled)
 					assert.False(t, res.Payload.Settings.TelemetryEnabled)
 				})
 			})
@@ -462,7 +462,7 @@ func TestSettings(t *testing.T) {
 				resg, err := serverClient.Default.Server.GetSettings(nil)
 				require.NoError(t, err)
 				assert.False(t, resg.Payload.Settings.TelemetryEnabled)
-				assert.False(t, resg.Payload.Settings.SttEnabled)
+				assert.True(t, resg.Payload.Settings.SttEnabled)
 
 				t.Run("EnableSTTWhileTelemetryDisabled", func(t *testing.T) {
 					defer restoreSettingsDefaults(t)

--- a/api-tests/server/settings_test.go
+++ b/api-tests/server/settings_test.go
@@ -44,7 +44,7 @@ func TestSettings(t *testing.T) {
 		res, err := serverClient.Default.Server.GetSettings(nil)
 		require.NoError(t, err)
 		assert.True(t, res.Payload.Settings.TelemetryEnabled)
-		assert.False(t, res.Payload.Settings.SttEnabled)
+		assert.True(t, res.Payload.Settings.SttEnabled)
 		expected := &server.GetSettingsOKBodySettingsMetricsResolutions{
 			Hr: "5s",
 			Mr: "10s",
@@ -433,7 +433,7 @@ func TestSettings(t *testing.T) {
 					assert.True(t, resg.Payload.Settings.SttEnabled)
 				})
 
-				t.Run("DisableTelemetryWhileSTTEnabled", func(t *testing.T) {
+				t.Run("DisableSTTifTelemetryIsDisabled", func(t *testing.T) {
 					res, err := serverClient.Default.Server.ChangeSettings(&server.ChangeSettingsParams{
 						Body: server.ChangeSettingsBody{
 							DisableTelemetry: true,
@@ -441,7 +441,7 @@ func TestSettings(t *testing.T) {
 						Context: pmmapitests.Context,
 					})
 					require.NoError(t, err)
-					assert.True(t, res.Payload.Settings.SttEnabled)
+					assert.False(t, res.Payload.Settings.SttEnabled)
 					assert.False(t, res.Payload.Settings.TelemetryEnabled)
 				})
 			})
@@ -498,7 +498,7 @@ func TestSettings(t *testing.T) {
 					resg, err := serverClient.Default.Server.GetSettings(nil)
 					require.NoError(t, err)
 					assert.True(t, resg.Payload.Settings.TelemetryEnabled)
-					assert.False(t, resg.Payload.Settings.SttEnabled)
+					assert.True(t, resg.Payload.Settings.SttEnabled)
 				})
 			})
 

--- a/models/database.go
+++ b/models/database.go
@@ -704,6 +704,9 @@ var databaseSchema = [][]string{
 			ADD COLUMN pmm_server_name VARCHAR NOT NULL,
 			ALTER COLUMN organization_id SET NOT NULL`,
 	},
+	61: {
+		`UPDATE settings SET settings = settings #- '{sass, stt_enabled}';`,
+	},
 }
 
 // ^^^ Avoid default values in schema definition. ^^^

--- a/models/settings.go
+++ b/models/settings.go
@@ -34,7 +34,7 @@ type MetricsResolutions struct {
 // SaaS contains settings related to the SaaS platform.
 type SaaS struct {
 	// Security Threat Tool enabled
-	STTEnabled bool `json:"stt_enabled"`
+	STTDisabled bool `json:"stt_enabled"`
 	// List of disabled STT checks
 	DisabledSTTChecks []string `json:"disabled_stt_checks"`
 	// STT check intervals
@@ -180,7 +180,7 @@ func (s *Settings) fillDefaults() {
 	// AWSInstanceChecked is false by default
 	// SSHKey is empty by default
 	// AlertManagerURL is empty by default
-	// SaaS.STTEnabled is false by default
+	// SaaS.STTDisabled is false by default
 	// DBaaS.Enabled is false by default
 	// IntegratedAlerting.Enabled is false by default
 	// VictoriaMetrics CacheEnable is false by default

--- a/models/settings.go
+++ b/models/settings.go
@@ -33,8 +33,8 @@ type MetricsResolutions struct {
 
 // SaaS contains settings related to the SaaS platform.
 type SaaS struct {
-	// Security Threat Tool enabled
-	STTDisabled bool `json:"stt_enabled"`
+	// Advisor checks disabled, false by default.
+	STTDisabled bool `json:"stt_disabled"`
 	// List of disabled STT checks
 	DisabledSTTChecks []string `json:"disabled_stt_checks"`
 	// STT check intervals

--- a/models/settings_helpers.go
+++ b/models/settings_helpers.go
@@ -38,11 +38,12 @@ func GetSettings(q reform.DBTX) (*Settings, error) {
 	}
 
 	var s Settings
+	s.fillDefaults()
+
 	if err := json.Unmarshal(b, &s); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal settings")
 	}
 
-	s.fillDefaults()
 	return &s, nil
 }
 
@@ -182,10 +183,10 @@ func UpdateSettings(q reform.DBTX, params *ChangeSettingsParams) (*Settings, err
 	}
 
 	if params.DisableSTT {
-		settings.SaaS.STTEnabled = false
+		settings.SaaS.STTDisabled = false
 	}
 	if params.EnableSTT {
-		settings.SaaS.STTEnabled = true
+		settings.SaaS.STTDisabled = true
 	}
 
 	if params.STTCheckIntervals.RareInterval != 0 {

--- a/models/settings_helpers.go
+++ b/models/settings_helpers.go
@@ -152,6 +152,7 @@ func UpdateSettings(q reform.DBTX, params *ChangeSettingsParams) (*Settings, err
 	if params.DisableTelemetry {
 		settings.Telemetry.Disabled = true
 		settings.Telemetry.UUID = ""
+		settings.SaaS.STTDisabled = true
 	}
 	if params.EnableTelemetry {
 		settings.Telemetry.Disabled = false
@@ -183,10 +184,10 @@ func UpdateSettings(q reform.DBTX, params *ChangeSettingsParams) (*Settings, err
 	}
 
 	if params.DisableSTT {
-		settings.SaaS.STTDisabled = false
+		settings.SaaS.STTDisabled = true
 	}
 	if params.EnableSTT {
-		settings.SaaS.STTDisabled = true
+		settings.SaaS.STTDisabled = false
 	}
 
 	if params.STTCheckIntervals.RareInterval != 0 {

--- a/models/settings_helpers.go
+++ b/models/settings_helpers.go
@@ -38,11 +38,11 @@ func GetSettings(q reform.DBTX) (*Settings, error) {
 	}
 
 	var s Settings
-	s.fillDefaults()
 
 	if err := json.Unmarshal(b, &s); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal settings")
 	}
+	s.fillDefaults()
 
 	return &s, nil
 }

--- a/models/settings_helpers.go
+++ b/models/settings_helpers.go
@@ -152,7 +152,6 @@ func UpdateSettings(q reform.DBTX, params *ChangeSettingsParams) (*Settings, err
 	if params.DisableTelemetry {
 		settings.Telemetry.Disabled = true
 		settings.Telemetry.UUID = ""
-		settings.SaaS.STTDisabled = true
 	}
 	if params.EnableTelemetry {
 		settings.Telemetry.Disabled = false

--- a/models/settings_helpers_test.go
+++ b/models/settings_helpers_test.go
@@ -238,7 +238,7 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.True(t, ns.Telemetry.Disabled)
-			assert.True(t, ns.SaaS.STTDisabled)
+			assert.False(t, ns.SaaS.STTDisabled)
 
 			// disable STT, enable Telemetry
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
@@ -246,7 +246,8 @@ func TestSettings(t *testing.T) {
 				DisableSTT:      true,
 			})
 			require.NoError(t, err)
-			assert.True(t, ns.Telemetry.Disabled)
+			assert.False(t, ns.Telemetry.Disabled)
+			assert.True(t, ns.SaaS.STTDisabled)
 
 			// enable both
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
@@ -262,14 +263,14 @@ func TestSettings(t *testing.T) {
 				DisableSTT: true,
 			})
 			require.NoError(t, err)
-			assert.True(t, ns.Telemetry.Disabled)
+			assert.False(t, ns.Telemetry.Disabled)
 			assert.True(t, ns.SaaS.STTDisabled)
 
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableSTT: true,
 			})
 			require.NoError(t, err)
-			assert.True(t, ns.Telemetry.Disabled)
+			assert.False(t, ns.Telemetry.Disabled)
 			assert.False(t, ns.SaaS.STTDisabled)
 
 			// restore initial default state

--- a/models/settings_helpers_test.go
+++ b/models/settings_helpers_test.go
@@ -231,14 +231,22 @@ func TestSettings(t *testing.T) {
 			assert.True(t, errors.As(err, &errInvalidArgument))
 			assert.EqualError(t, err, `invalid argument: both enable_stt and disable_stt are present`)
 
-			// disable both Advisor Checks and Telemetry
+			// disable telemetry, enable STT
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
-				DisableSTT:       true,
 				DisableTelemetry: true,
+				EnableSTT:        true,
 			})
 			require.NoError(t, err)
 			assert.True(t, ns.Telemetry.Disabled)
 			assert.True(t, ns.SaaS.STTDisabled)
+
+			// disable STT, enable Telemetry
+			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
+				EnableTelemetry: true,
+				DisableSTT:      true,
+			})
+			require.NoError(t, err)
+			assert.True(t, ns.Telemetry.Disabled)
 
 			// enable both
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
@@ -248,12 +256,6 @@ func TestSettings(t *testing.T) {
 			require.NoError(t, err)
 			assert.False(t, ns.Telemetry.Disabled)
 			assert.False(t, ns.SaaS.STTDisabled)
-
-			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
-				DisableTelemetry: true,
-			})
-			require.NoError(t, err)
-			assert.True(t, ns.Telemetry.Disabled)
 
 			// disable STT
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{

--- a/models/settings_helpers_test.go
+++ b/models/settings_helpers_test.go
@@ -214,7 +214,7 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.False(t, ns.Telemetry.Disabled)
-			assert.False(t, ns.SaaS.STTEnabled)
+			assert.False(t, ns.SaaS.STTDisabled)
 
 			_, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableTelemetry:  true,
@@ -237,7 +237,7 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.True(t, ns.Telemetry.Disabled)
-			assert.True(t, ns.SaaS.STTEnabled)
+			assert.True(t, ns.SaaS.STTDisabled)
 
 			// enable both
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
@@ -246,7 +246,7 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.False(t, ns.Telemetry.Disabled)
-			assert.True(t, ns.SaaS.STTEnabled)
+			assert.True(t, ns.SaaS.STTDisabled)
 
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				DisableTelemetry: true,
@@ -260,14 +260,14 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.True(t, ns.Telemetry.Disabled)
-			assert.False(t, ns.SaaS.STTEnabled)
+			assert.False(t, ns.SaaS.STTDisabled)
 
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableSTT: true,
 			})
 			require.NoError(t, err)
 			assert.True(t, ns.Telemetry.Disabled)
-			assert.True(t, ns.SaaS.STTEnabled)
+			assert.True(t, ns.SaaS.STTDisabled)
 
 			// restore initial default state
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
@@ -276,7 +276,7 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.False(t, ns.Telemetry.Disabled)
-			assert.False(t, ns.SaaS.STTEnabled)
+			assert.False(t, ns.SaaS.STTDisabled)
 		})
 
 		t.Run("Check that telemetry disabling resets telemetry UUID", func(t *testing.T) {

--- a/models/settings_helpers_test.go
+++ b/models/settings_helpers_test.go
@@ -210,7 +210,7 @@ func TestSettings(t *testing.T) {
 			// ensure initial default state
 			ns, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableTelemetry: true,
-				DisableSTT:      true,
+				EnableSTT:       true,
 			})
 			require.NoError(t, err)
 			assert.False(t, ns.Telemetry.Disabled)
@@ -231,8 +231,9 @@ func TestSettings(t *testing.T) {
 			assert.True(t, errors.As(err, &errInvalidArgument))
 			assert.EqualError(t, err, `invalid argument: both enable_stt and disable_stt are present`)
 
+			// disable both Advisor Checks and Telemetry
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
-				EnableSTT:        true,
+				DisableSTT:       true,
 				DisableTelemetry: true,
 			})
 			require.NoError(t, err)
@@ -246,7 +247,7 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.False(t, ns.Telemetry.Disabled)
-			assert.True(t, ns.SaaS.STTDisabled)
+			assert.False(t, ns.SaaS.STTDisabled)
 
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				DisableTelemetry: true,
@@ -260,19 +261,19 @@ func TestSettings(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.True(t, ns.Telemetry.Disabled)
-			assert.False(t, ns.SaaS.STTDisabled)
+			assert.True(t, ns.SaaS.STTDisabled)
 
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableSTT: true,
 			})
 			require.NoError(t, err)
 			assert.True(t, ns.Telemetry.Disabled)
-			assert.True(t, ns.SaaS.STTDisabled)
+			assert.False(t, ns.SaaS.STTDisabled)
 
 			// restore initial default state
 			ns, err = models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableTelemetry: true,
-				DisableSTT:      true,
+				EnableSTT:       true,
 			})
 			require.NoError(t, err)
 			assert.False(t, ns.Telemetry.Disabled)

--- a/services/checks/checks.go
+++ b/services/checks/checks.go
@@ -278,7 +278,7 @@ func (s *Service) GetSecurityCheckResults() ([]services.CheckResult, error) {
 		return nil, err
 	}
 
-	if !settings.SaaS.STTEnabled {
+	if settings.SaaS.STTDisabled {
 		return nil, services.ErrSTTDisabled
 	}
 
@@ -292,7 +292,7 @@ func (s *Service) GetChecksResults(ctx context.Context, serviceID string) ([]ser
 		return nil, err
 	}
 
-	if !settings.SaaS.STTEnabled {
+	if settings.SaaS.STTDisabled {
 		return nil, services.ErrSTTDisabled
 	}
 
@@ -358,7 +358,7 @@ func (s *Service) runChecksGroup(ctx context.Context, intervalGroup check.Interv
 		return errors.WithStack(err)
 	}
 
-	if !settings.SaaS.STTEnabled {
+	if settings.SaaS.STTDisabled {
 		return services.ErrSTTDisabled
 	}
 
@@ -374,7 +374,7 @@ func (s *Service) StartChecks(checkNames []string) error {
 		return errors.WithStack(err)
 	}
 
-	if !settings.SaaS.STTEnabled {
+	if settings.SaaS.STTDisabled {
 		return services.ErrSTTDisabled
 	}
 

--- a/services/checks/checks_test.go
+++ b/services/checks/checks_test.go
@@ -653,8 +653,6 @@ func TestGetFailedChecks(t *testing.T) {
 	db := reform.NewDB(sqlDB, postgresql.Dialect, nil)
 
 	t.Run("no failed check for service", func(t *testing.T) {
-		t.Parallel()
-
 		var ams mockAlertmanagerService
 		ctx := context.Background()
 		ams.On("GetAlerts", ctx, mock.Anything).Return([]*ammodels.GettableAlert{}, nil)
@@ -668,8 +666,6 @@ func TestGetFailedChecks(t *testing.T) {
 	})
 
 	t.Run("non empty failed checks", func(t *testing.T) {
-		t.Parallel()
-
 		alertLabels := map[string]string{
 			model.AlertNameLabel: "test_check",
 			"alert_id":           "test_alert",
@@ -725,8 +721,6 @@ func TestGetFailedChecks(t *testing.T) {
 	})
 
 	t.Run("STT disabled", func(t *testing.T) {
-		t.Parallel()
-
 		ams := mockAlertmanagerService{}
 		ctx := context.Background()
 		ams.On("GetAlerts", ctx, mock.Anything).Return(nil, services.ErrSTTDisabled)

--- a/services/checks/checks_test.go
+++ b/services/checks/checks_test.go
@@ -661,12 +661,6 @@ func TestGetFailedChecks(t *testing.T) {
 
 		s, err := New(nil, &ams, db)
 		require.NoError(t, err)
-		settings, err := models.GetSettings(db)
-		require.NoError(t, err)
-
-		settings.SaaS.STTDisabled = false
-		err = models.SaveSettings(db, settings)
-		require.NoError(t, err)
 
 		results, err := s.GetChecksResults(context.Background(), "test_svc")
 		assert.Empty(t, results)
@@ -723,12 +717,6 @@ func TestGetFailedChecks(t *testing.T) {
 		ams.On("GetAlerts", ctx, mock.Anything).Return([]*ammodels.GettableAlert{&testAlert}, nil)
 
 		s, err := New(nil, &ams, db)
-		require.NoError(t, err)
-		settings, err := models.GetSettings(db)
-		require.NoError(t, err)
-
-		settings.SaaS.STTDisabled = false
-		err = models.SaveSettings(db, settings)
 		require.NoError(t, err)
 
 		response, err := s.GetChecksResults(ctx, "test_svc")

--- a/services/platform/platform.go
+++ b/services/platform/platform.go
@@ -132,7 +132,7 @@ func (s *Service) Connect(ctx context.Context, req *platformpb.ConnectRequest) (
 		return nil, errInternalServer
 	}
 
-	if settings.SaaS.STTEnabled {
+	if !settings.SaaS.STTDisabled {
 		s.checksService.CollectChecks(ctx)
 	}
 
@@ -188,7 +188,7 @@ func (s *Service) Disconnect(ctx context.Context, req *platformpb.DisconnectRequ
 		return nil, err // this is already a status error
 	}
 
-	if settings.SaaS.STTEnabled {
+	if !settings.SaaS.STTDisabled {
 		s.checksService.CollectChecks(ctx)
 	}
 

--- a/services/server/server.go
+++ b/services/server/server.go
@@ -448,7 +448,7 @@ func (s *Server) convertSettings(settings *models.Settings, connectedToPlatform 
 		SshKey:               settings.SSHKey,
 		AwsPartitions:        settings.AWSPartitions,
 		AlertManagerUrl:      settings.AlertManagerURL,
-		SttEnabled:           settings.SaaS.STTEnabled,
+		SttEnabled:           !settings.SaaS.STTDisabled,
 		DbaasEnabled:         settings.DBaaS.Enabled,
 		AzurediscoverEnabled: settings.Azurediscover.Enabled,
 		PmmPublicAddress:     settings.PMMPublicAddress,
@@ -704,7 +704,7 @@ func (s *Server) ChangeSettings(ctx context.Context, req *serverpb.ChangeSetting
 
 	// When STT moved from disabled state to enabled force checks download and execution.
 	var sttStarted bool
-	if !oldSettings.SaaS.STTEnabled && newSettings.SaaS.STTEnabled {
+	if oldSettings.SaaS.STTDisabled && !newSettings.SaaS.STTDisabled {
 		sttStarted = true
 		if err := s.checksService.StartChecks(nil); err != nil {
 			s.l.Error(err)
@@ -712,7 +712,7 @@ func (s *Server) ChangeSettings(ctx context.Context, req *serverpb.ChangeSetting
 	}
 
 	// When STT moved from enabled state to disabled drop all existing STT alerts.
-	if oldSettings.SaaS.STTEnabled && !newSettings.SaaS.STTEnabled {
+	if !oldSettings.SaaS.STTDisabled && newSettings.SaaS.STTDisabled {
 		s.checksService.CleanupAlerts()
 	}
 


### PR DESCRIPTION
PMM-9841
SUBMODULES-2482

This turns on advisors by default in PMM. Instead of setting STTEnabled to true, it renames STTEnabled to STTDisabled (which is false by default). This is to avoid having to deal with boolean pointers (since we still need to detect "absent" vs "false" cases).

This doesn't need any corresponding frontend change to work but ideally, we could also update it to use the updated fields for consistency.
